### PR TITLE
Fix compression/decompression bug when BlockDependency=true

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -187,11 +187,14 @@ func (z *Reader) Read(buf []byte) (n int, err error) {
 		// cannot decompress concurrently when dealing with block dependency
 		z.decompressBlock(zb, nil)
 		// the last block may not contain enough data
+		if len(z.window) == 0 {
+			z.window = make([]byte, winSize)
+		}
 		if len(zb.data) >= winSize {
-			if len(z.window) == 0 {
-				z.window = make([]byte, winSize)
-			}
 			copy(z.window, zb.data[len(zb.data)-winSize:])
+		} else {
+			copy(z.window, z.window[len(zb.data):])
+			copy(z.window[len(zb.data)+1:], zb.data)
 		}
 	}
 	z.wg.Wait()

--- a/writer.go
+++ b/writer.go
@@ -216,8 +216,15 @@ func (z *Writer) Write(buf []byte) (n int, err error) {
 			z.window = make([]byte, winSize)
 		}
 		// last buffer may be shorter than the window
-		if len(buf) > winSize {
+		if len(buf) >= winSize {
 			copy(z.window, buf[len(buf)-winSize:])
+		} else {
+			if len(buf) >= winSize {
+				copy(z.window, buf[len(buf)-winSize:])
+			} else {
+				copy(z.window, z.window[len(buf):])
+				copy(z.window[len(buf)+1:], buf)
+			}
 		}
 	}
 


### PR DESCRIPTION
If I understand correctly, the way compression with BlockDependency=true is supposed to work is that it uses the last 64K from previous blocks as the dictionary.

This patch brings this implementation inline with that. Without the changes the reader/writer, both tests fail.