### PR TITLE
close writer

### DIFF
--- a/lz4c/main.go
+++ b/lz4c/main.go
@@ -59,6 +59,9 @@ func main() {
 			if _, err := io.Copy(zw, in); err != nil {
 				log.Fatalf("Error while compressing input: %v", err)
 			}
+			if err := zw.Close(); err != nil {
+				log.Fatalf("Error while closing stream: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Without this fix, end mark was not written correctly.