### PR TITLE
Improve copy efficiency in block decompression

### DIFF
--- a/block.go
+++ b/block.go
@@ -101,11 +101,20 @@ func UncompressBlock(src, dst []byte, di int) (int, error) {
 		}
 
 		// copy the match (NB. match is at least 4 bytes long)
-		// NB. past di, copy() would write old bytes instead of
-		// the ones we just copied, so split the work into the largest chunk.
-		for ; mLen >= offset; mLen -= offset {
-			di += copy(dst[di:], dst[di-offset:di])
+		if mLen >= offset {
+			bytesToCopy := offset * (mLen / offset)
+			// Efficiently copy the match dst[di-offset:di] into the slice
+			// dst[di:di+bytesToCopy]
+			expanded := dst[di-offset : di+bytesToCopy]
+			n := offset
+			for n <= bytesToCopy+offset {
+				copy(expanded[n:], expanded[:n])
+				n *= 2
+			}
+			di += bytesToCopy
+			mLen -= bytesToCopy
 		}
+
 		di += copy(dst[di:], dst[di-offset:di-offset+mLen])
 	}
 }

--- a/lz4_test.go
+++ b/lz4_test.go
@@ -295,6 +295,21 @@ func BenchmarkUncompressBlock(b *testing.B) {
 	}
 }
 
+func BenchmarkUncompressConstantBlock(b *testing.B) {
+	d := make([]byte, 4096)
+	z := make([]byte, 4096)
+	source := make([]byte, 4096)
+	n, err := lz4.CompressBlock(source, z, 0)
+	if err != nil {
+		b.Errorf("CompressBlock: %s", err)
+		b.FailNow()
+	}
+	z = z[:n]
+	for i := 0; i < b.N; i++ {
+		lz4.UncompressBlock(z, d, 0)
+	}
+}
+
 func BenchmarkCompressBlock(b *testing.B) {
 	d := append([]byte{}, lorem...)
 	z := make([]byte, len(lorem))
@@ -306,6 +321,20 @@ func BenchmarkCompressBlock(b *testing.B) {
 	z = z[:n]
 	for i := 0; i < b.N; i++ {
 		d = append([]byte{}, lorem...)
+		lz4.CompressBlock(d, z, 0)
+	}
+}
+
+func BenchmarkCompressConstantBlock(b *testing.B) {
+	d := make([]byte, 4096)
+	z := make([]byte, 4096)
+	n, err := lz4.CompressBlock(d, z, 0)
+	if err != nil {
+		b.Errorf("CompressBlock: %s", err)
+		b.FailNow()
+	}
+	z = z[:n]
+	for i := 0; i < b.N; i++ {
 		lz4.CompressBlock(d, z, 0)
 	}
 }


### PR DESCRIPTION
Currently, `UncompressBlock` can sometimes spend a lot of time copying matches
into the destination buffer. If `mLen` is much larger than `offset`,
which will happen when uncompressing constant or mostly-constant data,
then we can get significant speedup by using a more efficient copying
strategy. A new benchmark, `BenchmarkUncompressConstantBlock`, shows ~100x
faster decompression of a 4KB constant block with this change:

```
name                       old time/op  new time/op  delta
UncompressBlock-4           292ns ± 4%   293ns ± 4%     ~     (p=0.425 n=11+11)
UncompressConstantBlock-4  25.5µs ± 5%   0.3µs ± 4%  -98.93%  (p=0.000 n=11+11)
CompressBlock-4            19.4µs ± 5%  19.3µs ± 5%     ~     (p=0.973 n=11+10)
CompressBlockHC-4          38.2µs ± 6%  38.4µs ± 4%     ~     (p=0.760 n=11+11)
CompressEndToEnd-4         18.2µs ± 2%  18.1µs ± 4%     ~     (p=0.898 n=11+11)
```