### PR TITLE
Match backwards on matches

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,11 @@
 package lz4
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"os"
+	rdebug "runtime/debug"
+)
 
 var (
 	// ErrInvalidSourceShortBuffer is returned by UncompressBlock or CompressBLock when a compressed
@@ -13,7 +18,11 @@ var (
 )
 
 func recoverBlock(e *error) {
-	if recover() != nil && *e == nil {
+	if r := recover(); r != nil && *e == nil {
+		if debugFlag {
+			fmt.Fprintln(os.Stderr, r)
+			rdebug.PrintStack()
+		}
 		*e = ErrInvalidSourceShortBuffer
 	}
 }


### PR DESCRIPTION
Do backwards matching into the queued literals.

This seems to gain about 1.5% of compression I will add benchmarks later.

This could potentially make up for a smaller hash tables (15, maybe even 14 bits).

I will add that as a separate PR since the window size and hash table size is kinda mixed up.