### PR TITLE
Fix #58, block compression incompatibility with python library

### DIFF
--- a/block.go
+++ b/block.go
@@ -124,7 +124,7 @@ func CompressBlock(src, dst []byte, hashTable []int) (_ int, err error) {
 		si, mLen = si+mLen, si+minMatch
 
 		// Find the longest match by looking by batches of 8 bytes.
-		for si < sn {
+		for si+8 < sn {
 			x := binary.LittleEndian.Uint64(src[si:]) ^ binary.LittleEndian.Uint64(src[si-offset:])
 			if x == 0 {
 				si += 8

--- a/lz4.go
+++ b/lz4.go
@@ -38,7 +38,7 @@ const (
 	hashLog = 16
 	htSize  = 1 << hashLog
 
-	mfLimit = 8 + minMatch // The last match cannot start within the last 12 bytes.
+	mfLimit = 10 + minMatch // The last match cannot start within the last 14 bytes.
 )
 
 // map the block max size id with its value in bytes: 64Kb, 256Kb, 1Mb and 4Mb.


### PR DESCRIPTION
Did the minimal update suggested in #58 which solved the problem (thanks @klauspost )! No new tests added at this stage. Suggestions for relevant tests (without pulling in the python library) are welcome if such exist and you think they should be added.