### PR TITLE
fix import path to the internal xxh32

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -3,7 +3,7 @@ package lz4
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/pierrec/lz4/internal/xxh32"
+	"github.com/pierrec/lz4/v3/internal/xxh32"
 	"io"
 	"runtime"
 )


### PR DESCRIPTION
it is correct in the reader https://github.com/pierrec/lz4/blob/master/reader.go#L9