### PR TITLE
Make the hashTable argument to CompressBlock optional

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -10,19 +10,17 @@ import (
 )
 
 func BenchmarkCompress(b *testing.B) {
-	var hashTable [htSize]int
 	buf := make([]byte, len(pg1661))
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = lz4.CompressBlock(pg1661, buf, hashTable[:])
+		_, _ = lz4.CompressBlock(pg1661, buf, nil)
 	}
 }
 
 func BenchmarkCompressRandom(b *testing.B) {
-	var hashTable [htSize]int
 	buf := make([]byte, len(randomLZ4))
 
 	b.ReportAllocs()
@@ -30,7 +28,7 @@ func BenchmarkCompressRandom(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = lz4.CompressBlock(random, buf, hashTable[:])
+		_, _ = lz4.CompressBlock(random, buf, nil)
 	}
 }
 

--- a/block.go
+++ b/block.go
@@ -37,7 +37,7 @@ func UncompressBlock(src, dst []byte) (int, error) {
 // This is the fast version of LZ4 compression and also the default one.
 //
 // The argument hashTable is scratch space for a hash table used by the
-// compressor. It provided, it should have length at least 1<<16. If it is
+// compressor. If provided, it should have length at least 1<<16. If it is
 // shorter (or nil), CompressBlock allocates its own hash table.
 //
 // The size of the compressed data is returned. If it is 0 and no error, then the data is incompressible.

--- a/block.go
+++ b/block.go
@@ -35,7 +35,7 @@ func UncompressBlock(src, dst []byte) (int, error) {
 
 // CompressBlock compresses the source buffer into the destination one.
 // This is the fast version of LZ4 compression and also the default one.
-// The size of hashTable must be at least 64Kb.
+// The size of hashTable must be at least 1<<16.
 //
 // The size of the compressed data is returned. If it is 0 and no error, then the data is incompressible.
 //


### PR DESCRIPTION
This PR makes the hashTable argument to CompressBlock optional, as well as documenting it better. Compression speed is maintained; on amd64 with Go 1.14, benchmark results are

    name               old time/op    new time/op    delta
    Compress-8           3.15ms ± 1%    3.14ms ± 2%    ~     (p=0.549 n=9+10)
    CompressRandom-8     2.95µs ± 1%    2.86µs ± 1%  -3.13%  (p=0.000 n=9+10)
    SkipBytesPg1661-8     302µs ± 3%     299µs ± 1%    ~     (p=0.065 n=9+10)
    SkipBytesDigits-8    43.5µs ± 3%    47.3µs ± 1%  +8.77%  (p=0.000 n=10+10)
    SkipBytesTwain-8      197µs ± 1%     197µs ± 0%    ~     (p=0.211 n=9+10)
    SkipBytesRand-8      3.09µs ± 1%    3.09µs ± 1%    ~     (p=0.735 n=9+10)
    CompressPg1661-8     26.8µs ± 2%    26.9µs ± 1%    ~     (p=0.143 n=10+10)
    CompressDigits-8     3.64µs ± 1%    3.59µs ± 1%  -1.63%  (p=0.000 n=10+10)
    CompressTwain-8      17.1µs ± 1%    17.4µs ± 1%  +1.42%  (p=0.003 n=10+9)
    CompressRand-8        623ns ± 1%     626ns ± 3%    ~     (p=0.698 n=10+10)
    
    name               old alloc/op   new alloc/op   delta
    Compress-8            0.00B       1398.11B ± 3%   +Inf%  (p=0.000 n=10+9)
    CompressRandom-8      0.00B          1.00B ± 0%   +Inf%  (p=0.000 n=10+10)
    SkipBytesPg1661-8     0.00B          0.00B         ~     (all equal)
    SkipBytesDigits-8     0.00B          0.00B         ~     (all equal)
    SkipBytesTwain-8      0.00B          0.00B         ~     (all equal)
    SkipBytesRand-8       0.00B          0.00B         ~     (all equal)
    CompressPg1661-8      46.3B ± 2%     46.6B ± 1%    ~     (p=0.370 n=10+10)
    CompressDigits-8      52.6B ± 3%     52.2B ± 2%    ~     (p=0.424 n=8+9)
    CompressTwain-8       51.4B ± 1%     52.0B ± 0%  +1.17%  (p=0.011 n=10+10)
    CompressRand-8        57.8B ±15%     55.2B ±11%    ~     (p=0.220 n=10+9)
    
    name               old allocs/op  new allocs/op  delta
    Compress-8             0.00           0.00         ~     (all equal)
    CompressRandom-8       0.00           0.00         ~     (all equal)
    SkipBytesPg1661-8      0.00           0.00         ~     (all equal)
    SkipBytesDigits-8      0.00           0.00         ~     (all equal)
    SkipBytesTwain-8       0.00           0.00         ~     (all equal)
    SkipBytesRand-8        0.00           0.00         ~     (all equal)
    CompressPg1661-8       1.00 ± 0%      1.00 ± 0%    ~     (all equal)
    CompressDigits-8       1.00 ± 0%      1.00 ± 0%    ~     (all equal)
    CompressTwain-8        1.00 ± 0%      1.00 ± 0%    ~     (all equal)
    CompressRand-8         1.00 ± 0%      1.00 ± 0%    ~     (all equal)
    
    name               old speed      new speed      delta
    CompressRandom-8   5.55GB/s ± 1%  5.73GB/s ± 1%  +3.24%  (p=0.000 n=9+10)
    SkipBytesPg1661-8  1.97GB/s ± 3%  1.99GB/s ± 1%    ~     (p=0.065 n=9+10)
    SkipBytesDigits-8  2.30GB/s ± 3%  2.11GB/s ± 1%  -8.08%  (p=0.000 n=10+10)
    SkipBytesTwain-8   1.97GB/s ± 1%  1.97GB/s ± 0%    ~     (p=0.211 n=9+10)
    SkipBytesRand-8    5.30GB/s ± 1%  5.29GB/s ± 1%    ~     (p=0.720 n=9+10)
    CompressPg1661-8   22.2GB/s ± 2%  22.1GB/s ± 1%    ~     (p=0.143 n=10+10)
    CompressDigits-8   27.4GB/s ± 1%  27.9GB/s ± 1%  +1.66%  (p=0.000 n=10+10)
    CompressTwain-8    22.6GB/s ± 1%  22.3GB/s ± 1%  -1.40%  (p=0.003 n=10+9)
    CompressRand-8     26.3GB/s ± 1%  26.2GB/s ± 3%    ~     (p=0.684 n=10+10)
