### PR TITLE
Reset hashtable during Writer reset to ensure deterministic output.

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -3,9 +3,10 @@ package lz4
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/pierrec/lz4/internal/xxh32"
 	"io"
 	"runtime"
+
+	"github.com/pierrec/lz4/internal/xxh32"
 )
 
 // zResult contains the results of compressing a block.
@@ -370,6 +371,10 @@ func (z *Writer) Reset(w io.Writer) {
 	z.checksum.Reset()
 	z.idx = 0
 	z.err = nil
+	// reset hashtable to ensure deterministic output.
+	for i := range z.hashtable {
+		z.hashtable[i] = 0
+	}
 	z.WithConcurrency(n)
 }
 


### PR DESCRIPTION
Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>

Fixes #65