### PR TITLE
Fix previous commit that needs to convert pool returns.

### DIFF
--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -74,7 +74,7 @@ func CompressBlock(src, dst []byte, hashTable []int) (_ int, err error) {
 	}
 
 	if cap(hashTable) < htSize {
-		hashTable = HashTablePool.Get()
+		hashTable = HashTablePool.Get().([]int)
 		defer HashTablePool.Put(hashTable)
 	} else {
 		hashTable = hashTable[:htSize]
@@ -259,14 +259,14 @@ func CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTa
 	// hashTable: stores the last position found for a given hash
 	// chainTable: stores previous positions for a given hash
 	if cap(hashTable) < htSize {
-		hashTable = HashTablePool.Get()
+		hashTable = HashTablePool.Get().([]int)
 		defer HashTablePool.Put(hashTable)
 	} else {
 		hashTable = hashTable[:htSize]
 	}
 	_ = hashTable[htSize-1]
 	if cap(chainTable) < htSize {
-		chainTable = HashTablePool.Get()
+		chainTable = HashTablePool.Get().([]int)
 		defer HashTablePool.Put(chainTable)
 	} else {
 		chainTable = chainTable[:htSize]

--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -273,7 +273,7 @@ func CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTa
 	}
 	_ = chainTable[htSize-1]
 
-	if depth <= 0 {
+	if depth = 0 {
 		depth = winSize
 	}
 

--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -273,7 +273,7 @@ func CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTa
 	}
 	_ = chainTable[htSize-1]
 
-	if depth = 0 {
+	if depth == 0 {
 		depth = winSize
 	}
 

--- a/reader.go
+++ b/reader.go
@@ -152,7 +152,7 @@ func (r *Reader) reset(reader io.Reader) {
 //
 // w.Close must be called before Reset.
 func (r *Reader) Reset(reader io.Reader) {
-	r.frame.Magic = 0
+	_ = r.frame.CloseR(reader)
 	r.reset(reader)
 	r.state.state = noState
 	r.state.next(nil)

--- a/reader.go
+++ b/reader.go
@@ -152,6 +152,7 @@ func (r *Reader) reset(reader io.Reader) {
 //
 // w.Close must be called before Reset.
 func (r *Reader) Reset(reader io.Reader) {
+	r.frame.Magic = 0
 	r.reset(reader)
 	r.state.state = noState
 	r.state.next(nil)


### PR DESCRIPTION
Can't go get v4 because it doesn't compile.

Also I noted 2 staticcheck issue:
- One is fixed in this PR. (int32 can never be negative).
- The second one is more complex.

It seems that you want can to reuse hashtables([]int) with a sync.pool .

```
		chainTable = HashTablePool.Get().([]int)
		defer HashTablePool.Put(chainTable)
```

This cause https://staticcheck.io/docs/checks#SA6002. The problem is that you need to store it as pointer, otherwise the slice header is copied, not a bit deal but still 3 int allocations ( that could be avoided). I think you could create your own type or do a pointer dance here.

I wanted to help you fix this one but I realized you might want to remove the parameters in the function since you always passing nil ? e.g.
`CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTable []int)` = >
`CompressBlockHC(src, dst []byte, depth CompressionLevel)`

WDYT ?

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>