### PR TITLE
Speed up XXHZero

### DIFF
--- a/internal/xxh32/xxh32zero.go
+++ b/internal/xxh32/xxh32zero.go
@@ -79,8 +79,7 @@ func (xxh *XXHZero) Write(input []byte) (int, error) {
 	v1, v2, v3, v4 := xxh.v1, xxh.v2, xxh.v3, xxh.v4
 	if m > 0 {
 		// some data left from previous update
-		copy(xxh.buf[xxh.bufused:], input[:r])
-		xxh.bufused += len(input) - r
+		copy(xxh.buf[m:], input)
 
 		// fast rotl(13)
 		buf := xxh.buf[:16] // BCE hint.
@@ -89,7 +88,6 @@ func (xxh *XXHZero) Write(input []byte) (int, error) {
 		v3 = rol13(v3+binary.LittleEndian.Uint32(buf[8:])*prime2) * prime1
 		v4 = rol13(v4+binary.LittleEndian.Uint32(buf[12:])*prime2) * prime1
 		p = r
-		xxh.bufused = 0
 	}
 
 	for n := n - 16; p <= n; p += 16 {
@@ -101,8 +99,8 @@ func (xxh *XXHZero) Write(input []byte) (int, error) {
 	}
 	xxh.v1, xxh.v2, xxh.v3, xxh.v4 = v1, v2, v3, v4
 
-	copy(xxh.buf[xxh.bufused:], input[p:])
-	xxh.bufused += len(input) - p
+	copy(xxh.buf[:], input[p:])
+	xxh.bufused = len(input) - p
 
 	return n, nil
 }

--- a/internal/xxh32/xxh32zero_test.go
+++ b/internal/xxh32/xxh32zero_test.go
@@ -52,10 +52,10 @@ func TestZeroData(t *testing.T) {
 		_, _ = xxh.Write(data)
 
 		if got, want := xxh.Sum32(), td.sum; got != want {
-			t.Fatalf("got %d; want %d", got, want)
+			t.Fatalf("got %x; want %x", got, want)
 		}
 		if got, want := xxh32.ChecksumZero(data), td.sum; got != want {
-			t.Fatalf("got %d; want %d", got, want)
+			t.Fatalf("got %x; want %x", got, want)
 		}
 	}
 }
@@ -69,7 +69,7 @@ func TestZeroSplitData(t *testing.T) {
 		_, _ = xxh.Write(data[l:])
 
 		if got, want := xxh.Sum32(), td.sum; got != want {
-			t.Fatalf("got %d; want %d", got, want)
+			t.Fatalf("got %x; want %x", got, want)
 		}
 	}
 }
@@ -82,7 +82,7 @@ func TestZeroSum(t *testing.T) {
 		b := xxh.Sum(data)
 		h := binary.LittleEndian.Uint32(b[len(data):])
 		if got, want := h, td.sum; got != want {
-			t.Fatalf("got %d; want %d", got, want)
+			t.Fatalf("got %x; want %x", got, want)
 		}
 	}
 }
@@ -92,7 +92,7 @@ func TestZeroChecksum(t *testing.T) {
 		data := []byte(td.data)
 		h := xxh32.ChecksumZero(data)
 		if got, want := h, td.sum; got != want {
-			t.Fatalf("got %d; want %d", got, want)
+			t.Fatalf("got %x; want %x", got, want)
 		}
 	}
 }
@@ -103,7 +103,7 @@ func TestZeroReset(t *testing.T) {
 		_, _ = xxh.Write([]byte(td.data))
 		h := xxh.Sum32()
 		if got, want := h, td.sum; got != want {
-			t.Fatalf("got %d; want %d", got, want)
+			t.Fatalf("got %x; want %x", got, want)
 		}
 		xxh.Reset()
 	}


### PR DESCRIPTION
This patch speeds up XXHZero.Write by having it touch XXHZero.bufused fewer times; in particular, three writes have been replaced by only one.

Benchmark results on amd64:
    
    name      old time/op  new time/op  delta
    _XXH32-8  86.3ns ± 0%  82.3ns ± 0%  -4.60%  (p=0.000 n=7+10)