### PR TITLE
lz4.Reader.WriteTo should return number of bytes written

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -182,8 +182,8 @@ func (r *Reader) WriteTo(w io.Writer) (n int64, err error) {
 			return
 		}
 		r.handler(bn)
+		bn, err = w.Write(data[:bn])
 		n += int64(bn)
-		_, err = w.Write(data[:bn])
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
To conform to io.WriterTo, lz4.Reader.WriteTo should return the number of bytes that it has successfully written to its argument, not the number of bytes (compressed or uncompressed) that it consumed from its input.