### PR TITLE
Fix and test some corner cases in the decoders

### DIFF
--- a/internal/lz4block/decode_amd64.s
+++ b/internal/lz4block/decode_amd64.s
@@ -26,6 +26,8 @@ TEXT ·decodeBlock(SB), NOSPLIT, $64-56
 
 	MOVQ src_base+24(FP), SI
 	MOVQ src_len+32(FP), R9
+	CMPQ R9, $0
+	JE   err_corrupt
 	ADDQ SI, R9
 
 	// shortcut ends

--- a/internal/lz4block/decode_other.go
+++ b/internal/lz4block/decode_other.go
@@ -60,8 +60,10 @@ func decodeBlock(dst, src []byte) (ret int) {
 				di += lLen
 			}
 		}
-		if si >= uint(len(src)) {
+		if si == uint(len(src)) {
 			return int(di)
+		} else if si > uint(len(src)) {
+			return hasError
 		}
 
 		offset := uint(src[si]) | uint(src[si+1])<<8

--- a/internal/lz4block/decode_test.go
+++ b/internal/lz4block/decode_test.go
@@ -85,6 +85,11 @@ func TestBlockDecode(t *testing.T) {
 		exp  []byte
 	}{
 		{
+			"empty_input",
+			[]byte{0},
+			[]byte{},
+		},
+		{
 			"literal_only_short",
 			emitSeq("hello", 0, 0),
 			[]byte("hello"),
@@ -133,5 +138,30 @@ func TestBlockDecode(t *testing.T) {
 				t.Fatalf("expected %q got %q", test.exp, buf)
 			}
 		})
+	}
+}
+
+func TestDecodeBlockInvalid(t *testing.T) {
+	t.Parallel()
+
+	dst := make([]byte, 100)
+
+	for _, test := range []struct {
+		name string
+		src  string
+	}{
+		{
+			"empty_input",
+			"",
+		},
+		{
+			"final_lit_too_short",
+			"\x20a", // litlen = 2 but only a single-byte literal
+		},
+	} {
+		r := decodeBlock(dst, []byte(test.src))
+		if r >= 0 {
+			t.Errorf("no error for %s", test.name)
+		}
 	}
 }


### PR DESCRIPTION
amd64 and noasm disagreed about length-0 inputs and literals at the end of input. They now agree with each other and with lz4 1.9.2.