### PR TITLE
Smaller hashtables + block compression API

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -13,8 +13,11 @@ import (
 func BenchmarkCompress(b *testing.B) {
 	buf := make([]byte, len(pg1661))
 
+	n, _ := lz4block.CompressBlock(pg1661, buf, nil)
+
 	b.ReportAllocs()
 	b.ResetTimer()
+	b.ReportMetric(float64(n), "outbytes")
 
 	for i := 0; i < b.N; i++ {
 		_, _ = lz4block.CompressBlock(pg1661, buf, nil)
@@ -24,9 +27,12 @@ func BenchmarkCompress(b *testing.B) {
 func BenchmarkCompressRandom(b *testing.B) {
 	buf := make([]byte, len(randomLZ4))
 
+	n, _ := lz4block.CompressBlock(pg1661, buf, nil)
+
 	b.ReportAllocs()
 	b.SetBytes(int64(len(random)))
 	b.ResetTimer()
+	b.ReportMetric(float64(n), "outbytes")
 
 	for i := 0; i < b.N; i++ {
 		_, _ = lz4block.CompressBlock(random, buf, nil)
@@ -36,8 +42,11 @@ func BenchmarkCompressRandom(b *testing.B) {
 func BenchmarkCompressHC(b *testing.B) {
 	buf := make([]byte, len(pg1661))
 
+	n, _ := lz4block.CompressBlockHC(pg1661, buf, 16, nil, nil)
+
 	b.ReportAllocs()
 	b.ResetTimer()
+	b.ReportMetric(float64(n), "outbytes")
 
 	for i := 0; i < b.N; i++ {
 		_, _ = lz4block.CompressBlockHC(pg1661, buf, 16, nil, nil)
@@ -78,13 +87,13 @@ func benchmarkUncompress(b *testing.B, compressed []byte) {
 	r := bytes.NewReader(compressed)
 	zr := lz4.NewReader(r)
 
-	// Determine the uncompressed size of testfile.
-	uncompressedSize, err := io.Copy(ioutil.Discard, zr)
+	// Decompress once to determine the uncompressed size of testfile.
+	_, err := io.Copy(ioutil.Discard, zr)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	b.SetBytes(uncompressedSize)
+	b.SetBytes(int64(len(compressed)))
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -105,8 +114,8 @@ func benchmarkCompress(b *testing.B, uncompressed []byte) {
 	zw := lz4.NewWriter(w)
 	r := bytes.NewReader(uncompressed)
 
-	// Determine the compressed size of testfile.
-	compressedSize, err := io.Copy(zw, r)
+	// Compress once to determine the compressed size of testfile.
+	_, err := io.Copy(zw, r)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -114,9 +123,10 @@ func benchmarkCompress(b *testing.B, uncompressed []byte) {
 		b.Fatal(err)
 	}
 
-	b.SetBytes(compressedSize)
+	b.SetBytes(int64(len(uncompressed)))
 	b.ReportAllocs()
 	b.ResetTimer()
+	b.ReportMetric(float64(w.Len()), "outbytes")
 
 	for i := 0; i < b.N; i++ {
 		r.Reset(uncompressed)

--- a/bench_test.go
+++ b/bench_test.go
@@ -12,22 +12,24 @@ import (
 
 func BenchmarkCompress(b *testing.B) {
 	buf := make([]byte, len(pg1661))
+	var c lz4.Compressor
 
-	n, _ := lz4block.CompressBlock(pg1661, buf, nil)
+	n, _ := c.CompressBlock(pg1661, buf)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.ReportMetric(float64(n), "outbytes")
 
 	for i := 0; i < b.N; i++ {
-		_, _ = lz4block.CompressBlock(pg1661, buf, nil)
+		_, _ = c.CompressBlock(pg1661, buf)
 	}
 }
 
 func BenchmarkCompressRandom(b *testing.B) {
 	buf := make([]byte, len(randomLZ4))
+	var c lz4.Compressor
 
-	n, _ := lz4block.CompressBlock(pg1661, buf, nil)
+	n, _ := c.CompressBlock(pg1661, buf)
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(random)))
@@ -35,21 +37,22 @@ func BenchmarkCompressRandom(b *testing.B) {
 	b.ReportMetric(float64(n), "outbytes")
 
 	for i := 0; i < b.N; i++ {
-		_, _ = lz4block.CompressBlock(random, buf, nil)
+		_, _ = c.CompressBlock(random, buf)
 	}
 }
 
 func BenchmarkCompressHC(b *testing.B) {
 	buf := make([]byte, len(pg1661))
+	c := lz4.CompressorHC{Level: 16}
 
-	n, _ := lz4block.CompressBlockHC(pg1661, buf, 16, nil, nil)
+	n, _ := c.CompressBlock(pg1661, buf)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.ReportMetric(float64(n), "outbytes")
 
 	for i := 0; i < b.N; i++ {
-		_, _ = lz4block.CompressBlockHC(pg1661, buf, 16, nil, nil)
+		_, _ = c.CompressBlock(pg1661, buf)
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -37,7 +37,8 @@ func ExampleCompressBlock() {
 	data := []byte(strings.Repeat(s, 100))
 	buf := make([]byte, len(data))
 
-	n, err := lz4.CompressBlock(data, buf, nil)
+	var c lz4.Compressor
+	n, err := c.CompressBlock(data, buf)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -46,7 +47,7 @@ func ExampleCompressBlock() {
 	}
 	buf = buf[:n] // compressed data
 
-	// Allocated a very large buffer for decompression.
+	// Allocate a very large buffer for decompression.
 	out := make([]byte, 10*len(data))
 	n, err = lz4.UncompressBlock(buf, out)
 	if err != nil {

--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -25,23 +25,6 @@ const (
 	mfLimit = 10 + minMatch // The last match cannot start within the last 14 bytes.
 )
 
-// Pool of hash tables for CompressBlock.
-var HashTablePool = hashTablePool{sync.Pool{New: func() interface{} { return new([htSize]int) }}}
-
-type hashTablePool struct {
-	sync.Pool
-}
-
-func (p *hashTablePool) Get() *[htSize]int {
-	return p.Pool.Get().(*[htSize]int)
-}
-
-// Zero out the table to avoid non-deterministic outputs (see issue#65).
-func (p *hashTablePool) Put(t *[htSize]int) {
-	*t = [htSize]int{}
-	p.Pool.Put(t)
-}
-
 func recoverBlock(e *error) {
 	if r := recover(); r != nil && *e == nil {
 		*e = lz4errors.ErrInvalidSourceShortBuffer
@@ -68,7 +51,55 @@ func UncompressBlock(src, dst []byte) (int, error) {
 	return 0, lz4errors.ErrInvalidSourceShortBuffer
 }
 
-func CompressBlock(src, dst []byte, hashTable []int) (int, error) {
+type Compressor struct {
+	// Offsets are at most 64kiB, so we can store only the lower 16 bits of
+	// match positions: effectively, an offset from some 64kiB block boundary.
+	//
+	// When we retrieve such an offset, we interpret it as relative to the last
+	// block boundary si &^ 0xffff, or the one before, (si &^ 0xffff) - 0xffff,
+	// depending on which of these is inside the current window. If a table
+	// entry was generated more than 64kiB back in the input, we find out by
+	// inspecting the input stream.
+	table [htSize]uint16
+
+	needsReset bool
+}
+
+// Get returns the position of a presumptive match for the hash h.
+// The match may be a false positive due to a hash collision or an old entry.
+// If si < winSize, the return value may be negative.
+func (c *Compressor) get(h uint32, si int) int {
+	h &= htSize - 1
+	i := int(c.table[h])
+	i += si &^ winMask
+	if i >= si {
+		// Try previous 64kiB block (negative when in first block).
+		i -= winSize
+	}
+	return i
+}
+
+func (c *Compressor) put(h uint32, si int) {
+	h &= htSize - 1
+	c.table[h] = uint16(si)
+}
+
+var compressorPool = sync.Pool{New: func() interface{} { return new(Compressor) }}
+
+func CompressBlock(src, dst []byte) (int, error) {
+	c := compressorPool.Get().(*Compressor)
+	n, err := c.CompressBlock(src, dst)
+	compressorPool.Put(c)
+	return n, err
+}
+
+func (c *Compressor) CompressBlock(src, dst []byte) (int, error) {
+	if c.needsReset {
+		// Zero out reused table to avoid non-deterministic output (issue #65).
+		c.table = [htSize]uint16{}
+	}
+	c.needsReset = true // Only false on first call.
+
 	// Return 0, nil only if the destination buffer size is < CompressBlockBound.
 	isNotCompressible := len(dst) < CompressBlockBound(len(src))
 
@@ -85,15 +116,6 @@ func CompressBlock(src, dst []byte, hashTable []int) (int, error) {
 		goto lastLiterals
 	}
 
-	if cap(hashTable) < htSize {
-		poolTable := HashTablePool.Get()
-		defer HashTablePool.Put(poolTable)
-		hashTable = poolTable[:]
-	} else {
-		hashTable = hashTable[:htSize]
-	}
-	_ = hashTable[htSize-1]
-
 	// Fast scan strategy: the hash table only stores the last 4 bytes sequences.
 	for si < sn {
 		// Hash the next 6 bytes (sequence)...
@@ -103,33 +125,30 @@ func CompressBlock(src, dst []byte, hashTable []int) (int, error) {
 
 		// We check a match at s, s+1 and s+2 and pick the first one we get.
 		// Checking 3 only requires us to load the source one.
-		ref := hashTable[h]
-		ref2 := hashTable[h2]
-		hashTable[h] = si
-		hashTable[h2] = si + 1
+		ref := c.get(h, si)
+		ref2 := c.get(h2, si)
+		c.put(h, si)
+		c.put(h2, si+1)
+
 		offset := si - ref
 
-		// If offset <= 0 we got an old entry in the hash table.
-		if offset <= 0 || offset >= winSize || // Out of window.
-			uint32(match) != binary.LittleEndian.Uint32(src[ref:]) { // Hash collision on different matches.
+		if ref < 0 || uint32(match) != binary.LittleEndian.Uint32(src[ref:]) {
 			// No match. Start calculating another hash.
 			// The processor can usually do this out-of-order.
 			h = blockHash(match >> 16)
-			ref = hashTable[h]
+			ref3 := c.get(h, si+2)
 
 			// Check the second match at si+1
 			si += 1
 			offset = si - ref2
 
-			if offset <= 0 || offset >= winSize ||
-				uint32(match>>8) != binary.LittleEndian.Uint32(src[ref2:]) {
+			if ref2 < 0 || uint32(match>>8) != binary.LittleEndian.Uint32(src[ref2:]) {
 				// No match. Check the third match at si+2
 				si += 1
-				offset = si - ref
-				hashTable[h] = si
+				offset = si - ref3
+				c.put(h, si)
 
-				if offset <= 0 || offset >= winSize ||
-					uint32(match>>16) != binary.LittleEndian.Uint32(src[ref:]) {
+				if ref3 < 0 || uint32(match>>16) != binary.LittleEndian.Uint32(src[ref3:]) {
 					// Skip one extra byte (at si+3) before we check 3 matches again.
 					si += 2 + (si-anchor)>>adaptSkipLog
 					continue
@@ -221,7 +240,7 @@ func CompressBlock(src, dst []byte, hashTable []int) (int, error) {
 		}
 		// Hash match end-2
 		h = blockHash(binary.LittleEndian.Uint64(src[si-2:]))
-		hashTable[h] = si - 2
+		c.put(h, si-2)
 	}
 
 lastLiterals:
@@ -269,7 +288,30 @@ func blockHashHC(x uint32) uint32 {
 	return x * hasher >> (32 - winSizeLog)
 }
 
-func CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTable []int) (_ int, err error) {
+type CompressorHC struct {
+	// hashTable: stores the last position found for a given hash
+	// chainTable: stores previous positions for a given hash
+	hashTable, chainTable [htSize]int
+	needsReset            bool
+}
+
+var compressorHCPool = sync.Pool{New: func() interface{} { return new(CompressorHC) }}
+
+func CompressBlockHC(src, dst []byte, depth CompressionLevel) (int, error) {
+	c := compressorHCPool.Get().(*CompressorHC)
+	n, err := c.CompressBlock(src, dst, depth)
+	compressorHCPool.Put(c)
+	return n, err
+}
+
+func (c *CompressorHC) CompressBlock(src, dst []byte, depth CompressionLevel) (_ int, err error) {
+	if c.needsReset {
+		// Zero out reused table to avoid non-deterministic output (issue #65).
+		c.hashTable = [htSize]int{}
+		c.chainTable = [htSize]int{}
+	}
+	c.needsReset = true // Only false on first call.
+
 	defer recoverBlock(&err)
 
 	// Return 0, nil only if the destination buffer size is < CompressBlockBound.
@@ -286,25 +328,6 @@ func CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTa
 		goto lastLiterals
 	}
 
-	// hashTable: stores the last position found for a given hash
-	// chainTable: stores previous positions for a given hash
-	if cap(hashTable) < htSize {
-		poolTable := HashTablePool.Get()
-		defer HashTablePool.Put(poolTable)
-		hashTable = poolTable[:]
-	} else {
-		hashTable = hashTable[:htSize]
-	}
-	_ = hashTable[htSize-1]
-	if cap(chainTable) < htSize {
-		poolTable := HashTablePool.Get()
-		defer HashTablePool.Put(poolTable)
-		chainTable = poolTable[:]
-	} else {
-		chainTable = chainTable[:htSize]
-	}
-	_ = chainTable[htSize-1]
-
 	if depth == 0 {
 		depth = winSize
 	}
@@ -317,7 +340,7 @@ func CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTa
 		// Follow the chain until out of window and give the longest match.
 		mLen := 0
 		offset := 0
-		for next, try := hashTable[h], depth; try > 0 && next > 0 && si-next < winSize; next, try = chainTable[next&winMask], try-1 {
+		for next, try := c.hashTable[h], depth; try > 0 && next > 0 && si-next < winSize; next, try = c.chainTable[next&winMask], try-1 {
 			// The first (mLen==0) or next byte (mLen>=minMatch) at current match length
 			// must match to improve on the match length.
 			if src[next+mLen] != src[si+mLen] {
@@ -344,8 +367,8 @@ func CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTa
 			offset = si - next
 			// Try another previous position with the same hash.
 		}
-		chainTable[si&winMask] = hashTable[h]
-		hashTable[h] = si
+		c.chainTable[si&winMask] = c.hashTable[h]
+		c.hashTable[h] = si
 
 		// No match found.
 		if mLen == 0 {
@@ -364,8 +387,8 @@ func CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTa
 			match >>= 8
 			match |= uint32(src[si+3]) << 24
 			h := blockHashHC(match)
-			chainTable[si&winMask] = hashTable[h]
-			hashTable[h] = si
+			c.chainTable[si&winMask] = c.hashTable[h]
+			c.hashTable[h] = si
 			si++
 		}
 

--- a/internal/lz4block/block_test.go
+++ b/internal/lz4block/block_test.go
@@ -98,7 +98,7 @@ func TestCompressUncompressBlock(t *testing.T) {
 			tc := tc
 			t.Run(tc.file, func(t *testing.T) {
 				n = run(t, tc, func(src, dst []byte) (int, error) {
-					return lz4block.CompressBlock(src, dst, nil)
+					return lz4block.CompressBlock(src, dst)
 				})
 			})
 			t.Run(fmt.Sprintf("%s HC", tc.file), func(t *testing.T) {
@@ -138,13 +138,13 @@ func TestCompressCornerCase_CopyDstUpperBound(t *testing.T) {
 	t.Run(file, func(t *testing.T) {
 		t.Parallel()
 		run(src, func(src, dst []byte) (int, error) {
-			return lz4block.CompressBlock(src, dst, nil)
+			return lz4block.CompressBlock(src, dst)
 		})
 	})
 	t.Run(fmt.Sprintf("%s HC", file), func(t *testing.T) {
 		t.Parallel()
 		run(src, func(src, dst []byte) (int, error) {
-			return lz4block.CompressBlockHC(src, dst, 16, nil, nil)
+			return lz4block.CompressBlockHC(src, dst, 16)
 		})
 	})
 }
@@ -158,7 +158,7 @@ func TestIssue23(t *testing.T) {
 			buf[i] = 1
 		}
 
-		n, _ := lz4block.CompressBlock(buf[:], compressBuf, nil)
+		n, _ := lz4block.CompressBlock(buf[:], compressBuf)
 		if got, want := n, 300; got > want {
 			t.Fatalf("not able to compress repeated data: got %d; want %d", got, want)
 		}

--- a/internal/lz4stream/frame.go
+++ b/internal/lz4stream/frame.go
@@ -278,9 +278,9 @@ func (b *FrameDataBlock) Compress(f *Frame, src []byte, level lz4block.Compressi
 	var n int
 	switch level {
 	case lz4block.Fast:
-		n, _ = lz4block.CompressBlock(src, data, nil)
+		n, _ = lz4block.CompressBlock(src, data)
 	default:
-		n, _ = lz4block.CompressBlockHC(src, data, level, nil, nil)
+		n, _ = lz4block.CompressBlockHC(src, data, level)
 	}
 	if n == 0 {
 		b.Size.UncompressedSet(true)

--- a/lz4.go
+++ b/lz4.go
@@ -1,13 +1,11 @@
-// Package lz4 implements reading and writing lz4 compressed data (a frame),
-// as specified in http://fastcompression.blogspot.fr/2013/04/lz4-streaming-format-final.html.
+// Package lz4 implements reading and writing lz4 compressed data.
 //
-// Although the block level compression and decompression functions are exposed and are fully compatible
-// with the lz4 block format definition, they are low level and should not be used directly.
-// For a complete description of an lz4 compressed block, see:
-// http://fastcompression.blogspot.fr/2011/05/lz4-explained.html
+// The package supports both the LZ4 stream format,
+// as specified in http://fastcompression.blogspot.fr/2013/04/lz4-streaming-format-final.html,
+// and the LZ4 block format, defined at
+// http://fastcompression.blogspot.fr/2011/05/lz4-explained.html.
 //
 // See https://github.com/lz4/lz4 for the reference C implementation.
-//
 package lz4
 
 import (
@@ -40,6 +38,29 @@ func UncompressBlock(src, dst []byte) (int, error) {
 	return lz4block.UncompressBlock(src, dst)
 }
 
+// A Compressor compresses data into the LZ4 block format.
+// It uses a fast compression algorithm.
+//
+// A Compressor is not safe for concurrent use by multiple goroutines.
+//
+// Use a Writer to compress into the LZ4 stream format.
+type Compressor struct{ c lz4block.Compressor }
+
+// CompressBlockHC compresses the source buffer src into the destination dst.
+//
+// If compression is successful, the first return value is the size of the
+// compressed data, which is always >0.
+//
+// If dst has length at least CompressBlockBound(len(src)), compression always
+// succeeds. Otherwise, the first return value is zero. The error return is
+// non-nil if the compressed data does not fit in dst, but it might fit in a
+// larger buffer that is still smaller than CompressBlockBound(len(src)). The
+// return value (0, nil) means the data is likely incompressible and a buffer
+// of length CompressBlockBound(len(src)) should be passed in.
+func (c *Compressor) CompressBlock(src, dst []byte) (int, error) {
+	return c.c.CompressBlock(src, dst)
+}
+
 // CompressBlock compresses the source buffer into the destination one.
 // This is the fast version of LZ4 compression and also the default one.
 //
@@ -53,23 +74,50 @@ func UncompressBlock(src, dst []byte) (int, error) {
 // the compressed size is 0 and no error, then the data is incompressible.
 //
 // An error is returned if the destination buffer is too small.
-func CompressBlock(src, dst []byte, hashTable []int) (int, error) {
-	return lz4block.CompressBlock(src, dst, hashTable)
+
+// CompressBlock is equivalent to Compressor.CompressBlock.
+// The final argument is ignored and should be set to nil.
+//
+// This function is deprecated. Use a Compressor instead.
+func CompressBlock(src, dst []byte, _ []int) (int, error) {
+	return lz4block.CompressBlock(src, dst)
 }
 
-// CompressBlockHC compresses the source buffer src into the destination dst
-// with max search depth (use 0 or negative value for no max).
+// A CompressorHC compresses data into the LZ4 block format.
+// Its compression ratio is potentially better than that of a Compressor,
+// but it is also slower and requires more memory.
 //
-// CompressBlockHC compression ratio is better than CompressBlock but it is also slower.
+// A Compressor is not safe for concurrent use by multiple goroutines.
 //
-// The size of the compressed data is returned.
+// Use a Writer to compress into the LZ4 stream format.
+type CompressorHC struct {
+	// Level is the maximum search depth for compression.
+	// Values <= 0 mean no maximum.
+	Level CompressionLevel
+	c     lz4block.CompressorHC
+}
+
+// CompressBlockHC compresses the source buffer src into the destination dst.
 //
-// If the destination buffer size is lower than CompressBlockBound and
-// the compressed size is 0 and no error, then the data is incompressible.
+// If compression is successful, the first return value is the size of the
+// compressed data, which is always >0.
 //
-// An error is returned if the destination buffer is too small.
-func CompressBlockHC(src, dst []byte, depth CompressionLevel, hashTable, chainTable []int) (int, error) {
-	return lz4block.CompressBlockHC(src, dst, lz4block.CompressionLevel(depth), hashTable, chainTable)
+// If dst has length at least CompressBlockBound(len(src)), compression always
+// succeeds. Otherwise, the first return value is zero. The error return is
+// non-nil if the compressed data does not fit in dst, but it might fit in a
+// larger buffer that is still smaller than CompressBlockBound(len(src)). The
+// return value (0, nil) means the data is likely incompressible and a buffer
+// of length CompressBlockBound(len(src)) should be passed in.
+func (c *CompressorHC) CompressBlock(src, dst []byte) (int, error) {
+	return c.c.CompressBlock(src, dst, lz4block.CompressionLevel(c.Level))
+}
+
+// CompressBlockHC is equivalent to CompressorHC.CompressBlock.
+// The final two arguments are ignored and should be set to nil.
+//
+// This function is deprecated. Use a CompressorHC instead.
+func CompressBlockHC(src, dst []byte, depth CompressionLevel, _, _ []int) (int, error) {
+	return lz4block.CompressBlockHC(src, dst, lz4block.CompressionLevel(depth))
 }
 
 const (

--- a/writer_test.go
+++ b/writer_test.go
@@ -167,7 +167,7 @@ func TestIssue51(t *testing.T) {
 
 	zbuf := make([]byte, 8192)
 
-	n, err := lz4block.CompressBlock(data, zbuf, nil)
+	n, err := lz4block.CompressBlock(data, zbuf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestIssue71(t *testing.T) {
 
 			// Small buffer.
 			zSmall := make([]byte, bound-1)
-			n, err := lz4block.CompressBlock(src, zSmall, nil)
+			n, err := lz4block.CompressBlock(src, zSmall)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -205,7 +205,7 @@ func TestIssue71(t *testing.T) {
 
 			// Large enough buffer.
 			zLarge := make([]byte, bound)
-			n, err = lz4block.CompressBlock(src, zLarge, nil)
+			n, err = lz4block.CompressBlock(src, zLarge)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This is the PR promised in #92: uint64-typed hash tables for block compression (except in HC mode). It introduces a new API for block compression, while marking the old one deprecated, while also fixing some issues with the benchmarks. See the commit messages for details.

Benchmark results on amd64:

```
name              old time/op    new time/op    delta
Compress-8          3.13ms ± 3%    3.00ms ± 0%    -4.10%  (p=0.000 n=21+20)
CompressRandom-8    17.9µs ± 1%     8.6µs ± 1%   -51.78%  (p=0.000 n=19+20)
CompressHC-8        10.9ms ± 1%    10.2ms ± 1%    -6.12%  (p=0.000 n=21+20)
CompressPg1661-8     685µs ± 3%     699µs ± 2%    +2.05%  (p=0.000 n=21+21)
CompressDigits-8     649µs ± 3%     645µs ± 4%      ~     (p=0.083 n=19+21)
CompressTwain-8      676µs ± 2%     681µs ± 3%      ~     (p=0.078 n=20+21)
CompressRand-8       641µs ± 3%     627µs ± 2%    -2.18%  (p=0.000 n=21+21)

name              old alloc/op   new alloc/op   delta
Compress-8           923B ±100%        0B       -100.00%  (p=0.000 n=21+21)
CompressRandom-8    5.86B ±100%     0.00B       -100.00%  (p=0.000 n=21+21)
CompressHC-8        4.80kB ± 1%    0.00kB       -100.00%  (p=0.000 n=16+21)
CompressPg1661-8    4.25MB ± 1%    4.27MB ± 1%    +0.46%  (p=0.000 n=21+21)
CompressDigits-8    4.27MB ± 1%    4.25MB ± 1%    -0.58%  (p=0.000 n=21+20)
CompressTwain-8     4.25MB ± 1%    4.27MB ± 1%    +0.48%  (p=0.000 n=21+21)
CompressRand-8      4.26MB ± 0%    4.24MB ± 1%    -0.51%  (p=0.000 n=19+21)

name              old allocs/op  new allocs/op  delta
Compress-8            0.00           0.00           ~     (all equal)
CompressRandom-8      0.00           0.00           ~     (all equal)
CompressHC-8          0.00           0.00           ~     (all equal)
CompressPg1661-8      4.00 ± 0%      4.00 ± 0%      ~     (all equal)
CompressDigits-8      4.00 ± 0%      4.00 ± 0%      ~     (all equal)
CompressTwain-8       4.00 ± 0%      4.00 ± 0%      ~     (all equal)
CompressRand-8        4.00 ± 0%      4.00 ± 0%      ~     (all equal)

name              old speed      new speed      delta
CompressRandom-8   917MB/s ± 1%  1902MB/s ± 1%  +107.39%  (p=0.000 n=19+20)
CompressPg1661-8   868MB/s ± 3%   851MB/s ± 2%    -2.01%  (p=0.000 n=21+21)
CompressDigits-8   154MB/s ± 3%   155MB/s ± 4%      ~     (p=0.051 n=20+21)
CompressTwain-8    573MB/s ± 4%   570MB/s ± 3%      ~     (p=0.153 n=21+21)
CompressRand-8    25.6MB/s ± 3%  26.1MB/s ± 2%    +2.21%  (p=0.000 n=21+21)

name              old outbytes   new outbytes   delta
Compress-8            329k ± 0%      329k ± 0%      ~     (p=1.000 n=1+1)
CompressRandom-8      0.00           0.00           ~     (all equal)
CompressHC-8          288k ± 0%      288k ± 0%      ~     (all equal)
CompressPg1661-8      329k ± 0%      329k ± 0%      ~     (p=1.000 n=1+1)
CompressDigits-8      100k ± 0%      100k ± 0%      ~     (all equal)
CompressTwain-8       227k ± 0%      227k ± 0%      ~     (p=1.000 n=1+1)
CompressRand-8       16.4k ± 0%     16.4k ± 0%      ~     (all equal)
```

On the Raspberry Pi 4:

```
name              old time/op    new time/op    delta
Compress-4          14.9ms ± 2%    16.8ms ± 2%   +12.45%  (p=0.000 n=20+20)
CompressRandom-4     126µs ± 2%     126µs ± 2%      ~     (p=0.758 n=20+20)
CompressHC-4        44.7ms ± 4%    49.0ms ± 2%    +9.74%  (p=0.000 n=19+17)
CompressPg1661-4    2.78ms ±29%    2.71ms ± 3%      ~     (p=0.178 n=16+20)
CompressDigits-4    1.90ms ± 4%    1.89ms ± 2%      ~     (p=0.631 n=16+17)
CompressTwain-4     2.33ms ± 3%    2.33ms ± 3%      ~     (p=0.931 n=19+19)
CompressRand-4      1.88ms ± 4%    1.89ms ± 2%      ~     (p=0.196 n=20+18)

name              old alloc/op   new alloc/op   delta
Compress-4         1.86kB ±100%    0.00kB       -100.00%  (p=0.000 n=20+19)
CompressRandom-4    19.5B ±100%      0.0B       -100.00%  (p=0.000 n=20+20)
CompressHC-4       5.59kB ±100%    0.00kB       -100.00%  (p=0.000 n=20+20)
CompressPg1661-4    4.20MB ± 0%    4.20MB ± 1%      ~     (p=0.429 n=20+20)
CompressDigits-4    4.20MB ± 0%    4.20MB ± 0%      ~     (p=0.255 n=19+19)
CompressTwain-4     4.20MB ± 0%    4.19MB ± 0%    -0.12%  (p=0.036 n=20+19)
CompressRand-4      4.20MB ± 0%    4.20MB ± 0%      ~     (p=0.659 n=20+20)

name              old allocs/op  new allocs/op  delta
Compress-4            0.00           0.00           ~     (all equal)
CompressRandom-4      0.00           0.00           ~     (all equal)
CompressHC-4          0.00           0.00           ~     (all equal)
CompressPg1661-4      4.00 ± 0%      4.00 ± 0%      ~     (all equal)
CompressDigits-4      4.00 ± 0%      4.00 ± 0%      ~     (all equal)
CompressTwain-4       4.00 ± 0%      4.00 ± 0%      ~     (all equal)
CompressRand-4        4.00 ± 0%      4.00 ± 0%      ~     (all equal)

name              old speed      new speed      delta
CompressRandom-4   130MB/s ± 2%   130MB/s ± 2%      ~     (p=0.753 n=20+20)
CompressPg1661-4   215MB/s ±23%   220MB/s ± 3%      ~     (p=0.178 n=16+20)
CompressDigits-4  52.7MB/s ± 4%  52.8MB/s ± 2%      ~     (p=0.612 n=16+17)
CompressTwain-4    167MB/s ± 3%   166MB/s ± 4%      ~     (p=0.713 n=19+20)
CompressRand-4    8.71MB/s ± 4%  8.67MB/s ± 3%      ~     (p=0.214 n=20+18)
```