### PR TITLE
Faster uint16 loading in portable decoder

### DIFF
--- a/internal/lz4block/decode_other.go
+++ b/internal/lz4block/decode_other.go
@@ -2,6 +2,8 @@
 
 package lz4block
 
+import "encoding/binary"
+
 func decodeBlock(dst, src []byte) (ret int) {
 	const hasError = -2
 	defer func() {
@@ -32,7 +34,7 @@ func decodeBlock(dst, src []byte) (ret int) {
 					// if the match length (4..18) fits within the literals, then copy
 					// all 18 bytes, even if not all are part of the literals.
 					mLen += 4
-					if offset := uint(src[si]) | uint(src[si+1])<<8; mLen <= offset {
+					if offset := u16(src[si:]); mLen <= offset {
 						i := di - offset
 						end := i + 18
 						if end > uint(len(dst)) {
@@ -66,7 +68,7 @@ func decodeBlock(dst, src []byte) (ret int) {
 			return hasError
 		}
 
-		offset := uint(src[si]) | uint(src[si+1])<<8
+		offset := u16(src[si:])
 		if offset == 0 {
 			return hasError
 		}
@@ -98,3 +100,5 @@ func decodeBlock(dst, src []byte) (ret int) {
 		di += uint(copy(dst[di:di+mLen], expanded[:mLen]))
 	}
 }
+
+func u16(p []byte) uint { return uint(binary.LittleEndian.Uint16(p)) }


### PR DESCRIPTION
LittleEndian.Uint16 translates to a 16-byte unaligned load on platforms that have one.

amd64 with -tags=noasm:

```
name                old speed      new speed      delta
UncompressPg1661-8   339MB/s ± 1%   339MB/s ± 1%    ~     (p=0.573 n=8+10)
UncompressDigits-8  1.23GB/s ± 1%  1.25GB/s ± 1%  +0.91%  (p=0.008 n=9+10)
UncompressTwain-8    361MB/s ± 1%   362MB/s ± 0%  +0.38%  (p=0.009 n=9+10)
UncompressRand-8    3.76GB/s ± 2%  3.75GB/s ± 2%    ~     (p=0.684 n=10+10)
```

arm64:

```
name                old speed      new speed      delta
UncompressPg1661-8  57.7MB/s ± 1%  63.3MB/s ± 1%  +9.80%  (p=0.000 n=10+10)
UncompressDigits-8   205MB/s ± 1%   210MB/s ± 3%  +2.56%  (p=0.002 n=10+10)
UncompressTwain-8   60.0MB/s ± 1%  65.9MB/s ± 1%  +9.80%  (p=0.000 n=9+10)
UncompressRand-8     754MB/s ± 3%   745MB/s ± 4%    ~     (p=0.123 n=10+10)
```