### PR TITLE
Fix doc for v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # lz4 : LZ4 compression in pure Go
 
-[![GoDoc](https://godoc.org/github.com/pierrec/lz4?status.svg)](https://godoc.org/github.com/pierrec/lz4)
-[![Build Status](https://travis-ci.org/pierrec/lz4.svg?branch=master)](https://travis-ci.org/pierrec/lz4)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/pierrec/lz4/v4)](https://pkg.go.dev/github.com/pierrec/lz4/v4)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pierrec/lz4)](https://goreportcard.com/report/github.com/pierrec/lz4)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/pierrec/lz4.svg?style=social)](https://github.com/pierrec/lz4/tags)
 
@@ -15,13 +14,13 @@ The implementation is based on the reference C [one](https://github.com/lz4/lz4)
 Assuming you have the go toolchain installed:
 
 ```
-go get github.com/pierrec/lz4
+go get github.com/pierrec/lz4/v4
 ```
 
 There is a command line interface tool to compress and decompress LZ4 files.
 
 ```
-go install github.com/pierrec/lz4/cmd/lz4c
+go install github.com/pierrec/lz4/v4/cmd/lz4c
 ```
 
 Usage


### PR DESCRIPTION
I think it would be better to change the default branch setting for github of this repository to v4 as well.

The travis build also seems to be broken so I removed the badge.
I will also create a PR to add CI in github actions later.