### PR TITLE
Fix leak of FrameBlockData memory pool

### DIFF
--- a/internal/lz4stream/block.go
+++ b/internal/lz4stream/block.go
@@ -115,15 +115,18 @@ func (b *Blocks) initR(f *Frame, num int, src io.Reader) (chan []byte, error) {
 			block := NewFrameDataBlock(f)
 			cumx, err = block.Read(f, src, 0)
 			if err != nil {
+				block.Close(f)
 				break
 			}
 			// Recheck for an error as reading may be slow and uncompressing is expensive.
 			if b.ErrorR() != nil {
+				block.Close(f)
 				break
 			}
 			c := make(chan []byte)
 			blocks <- c
 			go func() {
+				defer block.Close(f)
 				data, err := block.Uncompress(f, size.Get(), false)
 				if err != nil {
 					b.closeR(err)


### PR DESCRIPTION
Close local variable of FrameBlockData, put buffer back to pool.