### PR TITLE
Fix out of bounds read in CompressBlock

### DIFF
--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -187,6 +187,9 @@ func (c *Compressor) CompressBlock(src, dst []byte) (int, error) {
 		}
 
 		mLen = si - mLen
+		if di >= len(dst) {
+			return 0, lz4errors.ErrInvalidSourceShortBuffer
+		}
 		if mLen < 0xF {
 			dst[di] = byte(mLen)
 		} else {

--- a/internal/lz4block/block_test.go
+++ b/internal/lz4block/block_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pierrec/lz4/v4"
 	"github.com/pierrec/lz4/v4/internal/lz4block"
+	"github.com/pierrec/lz4/v4/internal/lz4errors"
 )
 
 type testcase struct {
@@ -162,5 +163,21 @@ func TestIssue23(t *testing.T) {
 		if got, want := n, 300; got > want {
 			t.Fatalf("not able to compress repeated data: got %d; want %d", got, want)
 		}
+	}
+}
+
+func TestIssue116(t *testing.T) {
+	src, err := ioutil.ReadFile("../../fuzz/corpus/pg1661.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dst := make([]byte, len(src)-len(src)>>1)
+	lz4block.CompressBlock(src, dst)
+
+	var c lz4block.Compressor
+	_, err = c.CompressBlock(src, dst)
+	if err != lz4errors.ErrInvalidSourceShortBuffer {
+		t.Fatalf("expected %v, got nil", lz4errors.ErrInvalidSourceShortBuffer)
 	}
 }

--- a/internal/lz4block/decode_test.go
+++ b/internal/lz4block/decode_test.go
@@ -126,10 +126,9 @@ func TestBlockDecode(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			buf := make([]byte, len(test.exp))
 			n := decodeBlock(buf, test.src)
-			if n <= 0 {
-				t.Log(-n)
+			if n < 0 {
+				t.Log(n)
 			}
-
 			if !bytes.Equal(buf, test.exp) {
 				t.Fatalf("expected %q got %q", test.exp, buf)
 			}


### PR DESCRIPTION
Fixes #116. Includes the fuzz test that found it. The reproducer was already in the corpus.