### PR TITLE
lz4block: Use Go encoder with a dictionary on arm

### DIFF
--- a/internal/lz4block/decode_amd64.go
+++ b/internal/lz4block/decode_amd64.go
@@ -1,4 +1,3 @@
-// +build amd64 arm
 // +build !appengine
 // +build gc
 // +build !noasm

--- a/internal/lz4block/decode_arm.go
+++ b/internal/lz4block/decode_arm.go
@@ -1,0 +1,15 @@
+// +build gc,!noasm
+
+package lz4block
+
+func decodeBlock(dst, src, dict []byte) int {
+	if len(dict) == 0 {
+		return decodeBlockNodict(dst, src)
+	}
+	return decodeBlockGo(dst, src, dict)
+}
+
+// Assembler version of decodeBlock, without linked block support.
+
+//go:noescape
+func decodeBlockNodict(dst, src []byte) int

--- a/internal/lz4block/decode_arm.s
+++ b/internal/lz4block/decode_arm.s
@@ -19,8 +19,8 @@
 
 #define minMatch	$4
 
-// func decodeBlock(dst, src, dict []byte) int
-TEXT ·decodeBlock(SB), NOFRAME|NOSPLIT, $-4-40
+// func decodeBlockNodict(dst, src []byte) int
+TEXT ·decodeBlockNodict(SB), NOFRAME+NOSPLIT, $-4-28
 	MOVW dst_base  +0(FP), dst
 	MOVW dst_len   +4(FP), dstend
 	MOVW src_base +12(FP), src
@@ -183,7 +183,7 @@ copyMatchDone:
 
 end:
 	SUB  dstorig, dst, tmp1
-	MOVW tmp1, ret+36(FP)
+	MOVW tmp1, ret+24(FP)
 	RET
 
 	// The three error cases have distinct labels so we can put different
@@ -193,5 +193,5 @@ shortDst:
 shortSrc:
 corrupt:
 	MOVW $-1, tmp1
-	MOVW tmp1, ret+36(FP)
+	MOVW tmp1, ret+24(FP)
 	RET

--- a/internal/lz4block/decode_noasm.go
+++ b/internal/lz4block/decode_noasm.go
@@ -1,0 +1,7 @@
+// +build !amd64,!arm appengine !gc noasm
+
+package lz4block
+
+func decodeBlock(dst, src, dict []byte) int {
+	return decodeBlockGo(dst, src, dict)
+}

--- a/internal/lz4block/decode_other.go
+++ b/internal/lz4block/decode_other.go
@@ -1,12 +1,10 @@
-// +build !amd64,!arm appengine !gc noasm
-
 package lz4block
 
 import (
 	"encoding/binary"
 )
 
-func decodeBlock(dst, src, dict []byte) (ret int) {
+func decodeBlockGo(dst, src, dict []byte) (ret int) {
 	// Restrict capacities so we don't read or write out of bounds.
 	dst = dst[:len(dst):len(dst)]
 	src = src[:len(src):len(src)]


### PR DESCRIPTION
The Go decoder is now built unconditionally and used on arm if a dictionary is provided.

Tests pass on 386, amd64, arm, arm64 with and without noasm.