### PR TITLE
Writer should copy buffer in concurrency mode

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -89,7 +89,7 @@ func (w *Writer) Write(buf []byte) (n int, err error) {
 
 	zn := len(w.data)
 	for len(buf) > 0 {
-		if w.idx == 0 && len(buf) >= zn {
+		if w.isNotConcurrent() && w.idx == 0 && len(buf) >= zn {
 			// Avoid a copy as there is enough data for a block.
 			if err = w.write(buf[:zn], false); err != nil {
 				return


### PR DESCRIPTION
This PR fixes a bug that can damage the output when writing in concurrency mode.

In current code when calling `Write()`, the writer doesn't copy the input when the buffer is empty and remaining input data fits a block. It just calls `write()` with the reference of the input slice.

https://github.com/pierrec/lz4/blob/e14f98189f2e857c91b909d68e86c3e4e81b536d/writer.go#L92-L100

And in `write()`, if concurrency is enabled, the data is processed in a goroutine asynchronously, which means `Write()` may return before the input data is actually read.

https://github.com/pierrec/lz4/blob/e14f98189f2e857c91b909d68e86c3e4e81b536d/writer.go#L134-L144

As the goroutine only keeps a reference of the input slice, and the slice may be alerted after `Write()` has returned (such as `io.Copy()` reusing a single byte slice through the whole copying), the output can be damaged in such situation.

I have been troubled for mouths by mysterious faulty archive files (checksum error), but it seems rare and irreproducible. After I tuned the buffer size of `io.CopyBuffer()` yesterday, the error rate raised to nearly 100%. Then I found this bug after spending hours 😫.

I cannot find another way to stably reproduce it other than compressing a tar with a big file copied by `io.CopyBuffer()` with a rather big buffer. I have added it to the unit test.

May be related to #115.