### PR TITLE
fix for issue 125 - lz4 data corruption when concurrency is used

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -88,7 +88,7 @@ func (z *Writer) WithConcurrency(n int) *Writer {
 				// It is now safe to release the buffer as no longer in use by any goroutine.
 				putBuffer(cap(res.data), res.data)
 			} else {
-				// if the block is uncompressed, return it the buffer to the pool
+				// if the block is uncompressed, return it to the buffer to the pool
 				putBuffer(z.Header.BlockMaxSize, res.data)
 			}
 			if h := z.OnBlockDone; h != nil {

--- a/writer.go
+++ b/writer.go
@@ -173,7 +173,10 @@ func (z *Writer) writeHeader() error {
 
 // Write compresses data from the supplied buffer into the underlying io.Writer.
 // Write does not return until the data has been written.
-func (z *Writer) Write(buf []byte) (int, error) {
+func (z *Writer) Write(buffer []byte) (int, error) {
+	buf := make([]byte, len(buffer))
+	copy(buf, buffer)
+
 	if !z.Header.done {
 		if err := z.writeHeader(); err != nil {
 			return 0, err
@@ -223,7 +226,10 @@ func (z *Writer) Write(buf []byte) (int, error) {
 }
 
 // compressBlock compresses a block.
-func (z *Writer) compressBlock(data []byte) error {
+func (z *Writer) compressBlock(dataBlock []byte) error {
+	data := make([]byte, len(dataBlock))
+	copy(data, dataBlock)
+
 	if !z.NoChecksum {
 		_, _ = z.checksum.Write(data)
 	}


### PR DESCRIPTION
This is an attempt to fix https://github.com/pierrec/lz4/issues/125. I noticed corruption of the LZ4 stream happens only when concurrency is used (everything works fine without it)

When compressing, [the buffer gets sent to a go routine](https://github.com/rvrangel/lz4/blob/9c7f9a786e04857aa1253f2041d95aa52983be15/writer.go#L229-L242), but when concurrency is used, the underlying array might get modified before the execution starts. causing the output of the lz4 Writer to be corrupt. Creating a copy of the buffer before solves this issue.

I also did the same thing on the main `Write()` func because according to the [documentation of Writer](https://golang.org/pkg/io/#Writer):

> Write must not modify the slice data, even temporarily. 

The existing tests don't seem to have run into this because we read the entire file into memory and then use `bytes.NewReader()` to create the reader for the `Copy()` operation, however the [implementation shows that the data is copied into a new buffer](https://golang.org/src/bytes/reader.go?s=1154:1204#L30) and returned, which mitigates this issue. The tests included in this PR use `os.Open()` similarly to the implementation in `cmd/lz4c`.

Test before the fix:
```
$ go test -run TestIssue125
--- FAIL: TestIssue125 (0.00s)
    --- FAIL: TestIssue125/testdata/e.txt(0) (0.51s)
        writer_test.go:235: lz4: invalid frame checksum: got e9123de2; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/repeat.txt(0) (0.52s)
        writer_test.go:235: lz4: invalid frame checksum: got 782d80aa; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/repeat.txt(-1) (0.52s)
        writer_test.go:235: lz4: invalid frame checksum: got c9b8d78e; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/pg1661.txt(-1) (0.56s)
        writer_test.go:235: lz4: invalid frame checksum: got a640aa10; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/vmlinux_LZ4_19377(0) (0.57s)
        writer_test.go:235: lz4: invalid frame checksum: got 96c86c27; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/gettysburg.txt(4) (0.57s)
        writer_test.go:235: lz4: invalid frame checksum: got e9f7f4bc; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/vmlinux_LZ4_19377(-1) (0.58s)
        writer_test.go:235: lz4: invalid frame checksum: got f9f87705; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/vmlinux_LZ4_19377(4) (0.58s)
        writer_test.go:235: lz4: invalid frame checksum: got 51ce6e24; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/Mark.Twain-Tom.Sawyer.txt(0) (0.46s)
        writer_test.go:235: lz4: invalid frame checksum: got 899dbb55; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/gettysburg.txt(-1) (0.49s)
        writer_test.go:235: lz4: invalid frame checksum: got ea0c0152; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/repeat.txt(4) (0.49s)
        writer_test.go:235: lz4: invalid frame checksum: got 899dbb55; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/gettysburg.txt(0) (0.46s)
        writer_test.go:235: lz4: invalid frame checksum: got 35c63389; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/pg1661.txt(0) (0.48s)
        writer_test.go:235: lz4: invalid frame checksum: got 899dbb55; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/Mark.Twain-Tom.Sawyer_long.txt(-1) (0.50s)
        writer_test.go:235: lz4: invalid frame checksum: got e20cfe85; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/e.txt(-1) (0.49s)
        writer_test.go:235: lz4: invalid frame checksum: got c055f080; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/pg1661.txt(4) (0.49s)
        writer_test.go:235: lz4: invalid frame checksum: got 8e14c8d7; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/e.txt(4) (0.46s)
        writer_test.go:235: lz4: invalid frame checksum: got 7ef86c81; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/random.data(0) (0.47s)
        writer_test.go:235: lz4: invalid frame checksum: got 409aeaee; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/random.data(-1) (0.47s)
        writer_test.go:235: lz4: invalid frame checksum: got f4960c9; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/random.data(4) (0.44s)
        writer_test.go:235: lz4: invalid frame checksum: got ad143a6c; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/Mark.Twain-Tom.Sawyer_long.txt(0) (0.46s)
        writer_test.go:235: lz4: invalid frame checksum: got 7619ce5b; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/Mark.Twain-Tom.Sawyer_long.txt(4) (0.46s)
        writer_test.go:235: lz4: invalid frame checksum: got 3575d1ae; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/pi.txt(-1) (0.47s)
        writer_test.go:235: lz4: invalid frame checksum: got e563ca2d; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/pi.txt(4) (0.50s)
        writer_test.go:235: lz4: invalid frame checksum: got 2e8a7ec3; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/Mark.Twain-Tom.Sawyer.txt(-1) (0.29s)
        writer_test.go:235: lz4: invalid frame checksum: got 22efb42; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/pi.txt(0) (0.28s)
        writer_test.go:235: lz4: invalid frame checksum: got c59d9c75; expected 5ccb24d3
    --- FAIL: TestIssue125/testdata/Mark.Twain-Tom.Sawyer.txt(4) (0.28s)
        writer_test.go:235: lz4: invalid frame checksum: got 92fece44; expected 5ccb24d3
FAIL
exit status 1
FAIL	github.com/pierrec/lz4	1.778s
```

After the fix:
```
$ go test
PASS
ok  	github.com/pierrec/lz4	12.370s
```