### PR TITLE
Fix out-of-bounds write in CompressBlock

### DIFF
--- a/fuzz/lz4.go
+++ b/fuzz/lz4.go
@@ -81,7 +81,7 @@ func FuzzUncompressBlock(data []byte) int {
 	}
 	decomp = decomp[:len(data)]
 
-	n, err := lz4.UncompressBlock(data, decomp, nil)
+	n, err := lz4.UncompressBlock(data, decomp)
 	if n > len(decomp) {
 		panic("uncompressed length greater than buffer")
 	}

--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -203,9 +203,12 @@ func (c *Compressor) CompressBlock(src, dst []byte) (int, error) {
 			dst[di] |= 0xF0
 			di++
 			l := lLen - 0xF
-			for ; l >= 0xFF; l -= 0xFF {
+			for ; l >= 0xFF && di < len(dst); l -= 0xFF {
 				dst[di] = 0xFF
 				di++
+			}
+			if di >= len(dst) {
+				return 0, lz4errors.ErrInvalidSourceShortBuffer
 			}
 			dst[di] = byte(l)
 		}

--- a/internal/lz4block/block_test.go
+++ b/internal/lz4block/block_test.go
@@ -181,3 +181,22 @@ func TestIssue116(t *testing.T) {
 		t.Fatalf("expected %v, got nil", lz4errors.ErrInvalidSourceShortBuffer)
 	}
 }
+
+func TestWriteLiteralLen(t *testing.T) {
+	for _, c := range []struct {
+		dstlen int
+		src    string
+	}{
+		// These used to panic when writing literal lengths.
+		{41, "00000\b000\xa4000\xe6000\v00" +
+			"0\xb7000\xb8000#000\x820\x00\x00\x00\x00\x00" +
+			"\x00\x00\x00\x0000\xff0000\x00000,000e" +
+			"000000000000000000000"},
+		{62, "00000r000o000a000s000e000tion, 00000e000" +
+			"a0d0000t000p000tition, 0o000i000e0c0000o" +
+			"0 00000000000000000000000000000000000000000"},
+	} {
+		dst := make([]byte, c.dstlen)
+		lz4block.CompressBlock([]byte(c.src), dst)
+	}
+}


### PR DESCRIPTION
Includes a regression test and a fix to the fuzz test, which found this.