### PR TITLE
Hash five bytes instead of six

### DIFF
--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -31,10 +31,11 @@ func recoverBlock(e *error) {
 	}
 }
 
-// blockHash hashes the lower 6 bytes into a value < htSize.
+// blockHash hashes the lower five bytes of x into a value < htSize.
 func blockHash(x uint64) uint32 {
 	const prime6bytes = 227718039650203
-	return uint32(((x << (64 - 48)) * prime6bytes) >> (64 - hashLog))
+	x &= 1<<40 - 1
+	return uint32((x * prime6bytes) >> (64 - hashLog))
 }
 
 func CompressBlockBound(n int) int {
@@ -116,9 +117,9 @@ func (c *Compressor) CompressBlock(src, dst []byte) (int, error) {
 		goto lastLiterals
 	}
 
-	// Fast scan strategy: the hash table only stores the last 4 bytes sequences.
+	// Fast scan strategy: the hash table only stores the last five-byte sequences.
 	for si < sn {
-		// Hash the next 6 bytes (sequence)...
+		// Hash the next five bytes (sequence)...
 		match := binary.LittleEndian.Uint64(src[si:])
 		h := blockHash(match)
 		h2 := blockHash(match >> 8)


### PR DESCRIPTION
This changes CompressBlock to hash five bytes of input at a time, instead of six. This looks to be a better compromise than six, giving slightly better compression and no slowdown on the benchmarks. I've verified that on a different corpus (a collection of tiny blocks representative of my application), the compression ratio goes up slightly while throughput goes down by only a few percent.

I also tried four bytes, but found it to be much slower, even when I swapped in the constant from blockHashHC.

```
name              old time/op    new time/op    delta
Compress-8          3.01ms ± 2%    3.19ms ± 2%   +5.86%  (p=0.000 n=18+18)
CompressRandom-8    8.68µs ± 1%    8.63µs ± 1%   -0.55%  (p=0.000 n=20+20)
CompressPg1661-8     733µs ± 7%     702µs ± 4%   -4.17%  (p=0.000 n=20+20)
CompressDigits-8     665µs ± 2%     663µs ± 3%     ~     (p=0.512 n=20+20)
CompressTwain-8      713µs ± 2%     701µs ± 2%   -1.76%  (p=0.000 n=20+20)
CompressRand-8       649µs ± 2%     647µs ± 3%     ~     (p=0.383 n=20+20)

name              old outbytes   new outbytes   delta
Compress-8            329k ± 0%      324k ± 0%   -1.46%  (p=0.000 n=20+20)
CompressRandom-8      0.00           0.00          ~     (all equal)
CompressPg1661-8      329k ± 0%      324k ± 0%   -1.46%  (p=0.000 n=20+20)
CompressDigits-8      100k ± 0%       81k ± 0%  -18.98%  (p=0.000 n=20+20)
CompressTwain-8       227k ± 0%      222k ± 0%   -2.21%  (p=0.000 n=20+20)
CompressRand-8       16.4k ± 0%     16.4k ± 0%     ~     (all equal)

name              old alloc/op   new alloc/op   delta
Compress-8           0.00B          0.00B          ~     (all equal)
CompressRandom-8     0.00B          0.00B          ~     (all equal)
CompressPg1661-8    4.25MB ± 1%    4.25MB ± 1%     ~     (p=0.879 n=20+19)
CompressDigits-8    4.28MB ± 1%    4.29MB ± 1%   +0.28%  (p=0.008 n=20+20)
CompressTwain-8     4.27MB ± 1%    4.28MB ± 1%   +0.33%  (p=0.004 n=20+20)
CompressRand-8      4.26MB ± 1%    4.25MB ± 0%   -0.22%  (p=0.043 n=20+20)

name              old allocs/op  new allocs/op  delta
Compress-8            0.00           0.00          ~     (all equal)
CompressRandom-8      0.00           0.00          ~     (all equal)
CompressPg1661-8      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CompressDigits-8      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CompressTwain-8       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CompressRand-8        4.00 ± 0%      4.00 ± 0%     ~     (all equal)

name              old speed      new speed      delta
CompressRandom-8  1.89GB/s ± 1%  1.90GB/s ± 1%   +0.56%  (p=0.000 n=20+20)
CompressPg1661-8   813MB/s ± 7%   847MB/s ± 4%   +4.29%  (p=0.000 n=20+20)
CompressDigits-8   150MB/s ± 2%   151MB/s ± 3%     ~     (p=0.516 n=20+20)
CompressTwain-8    544MB/s ± 2%   554MB/s ± 2%   +1.79%  (p=0.000 n=20+20)
CompressRand-8    25.2MB/s ± 2%  25.3MB/s ± 3%     ~     (p=0.380 n=20+20)
```