### PR TITLE
Re-enable shortcut in amd64 decoder

### DIFF
--- a/internal/lz4block/decode_amd64.s
+++ b/internal/lz4block/decode_amd64.s
@@ -102,12 +102,10 @@ loop:
 	// match length, we already have the offset.
 	CMPQ CX, $0xF
 	JEQ match_len_loop_pre
-	CMPQ DX, R11
-	JLT match_len_loop_pre
 	CMPQ DX, $8
 	JLT match_len_loop_pre
 	CMPQ AX, R11
-	JLT err_short_buf
+	JLT match_len_loop_pre
 
 	// memcpy(op + 0, match + 0, 8);
 	MOVQ (AX), BX

--- a/internal/lz4block/decode_test.go
+++ b/internal/lz4block/decode_test.go
@@ -193,6 +193,11 @@ func TestDecodeWithDict(t *testing.T) {
 		// First part in dictionary, rest in dst.
 		{"\x35foo\x09\x00\x401234", "0barbaz", "foobarbazfoo1234"},
 
+		// Same, but >16 bytes before the end,
+		// to test the short match shortcut in the amd64 decoder.
+		{"\x35abc\x09\x00\xf0\x0f0123456789abcdefghijklmnopqrst", "012defghi",
+			"abcdefghiabc0123456789abcdefghijklmnopqrst"},
+
 		// Offset points before start of dictionary.
 		{"\x35foo\xff\xff\x401234", "XYZ", ""},
 	} {


### PR DESCRIPTION
8fa51c0606b39e338e7afcf19da5ab2b86874460 introduced a faulty check in the amd64 decoder: it skips the short match shortcut when offset < &dst[0], which implies &dst[0] < 0xffff. It should instead check whether (di-offset) < &dst[0] to find out if the match comes from the dictionary.

Fixing the check means preset dictionaries work with dst at any memory address, and undoes a major performance regression.

Benchmark results on Go 1.17-rc1, Linux/amd64:
    
    name                old time/op    new time/op    delta
    Uncompress-8          8.76ns ± 1%    8.81ns ± 2%     ~     (p=0.169 n=18+15)
    UncompressPg1661-8     359µs ± 1%     297µs ± 1%  -17.35%  (p=0.000 n=20+15)
    UncompressDigits-8    51.8µs ± 1%    47.8µs ± 2%   -7.66%  (p=0.000 n=20+15)
    UncompressTwain-8      236µs ± 1%     196µs ± 1%  -16.75%  (p=0.000 n=19+13)
    UncompressRand-8      4.22µs ± 2%    4.19µs ± 2%   -0.77%  (p=0.046 n=20+14)
    
    name                old alloc/op   new alloc/op   delta
    Uncompress-8           0.00B          0.00B          ~     (all equal)
    UncompressPg1661-8      184B ± 0%      184B ± 0%     ~     (all equal)
    UncompressDigits-8      190B ± 9%      192B ±12%     ~     (p=0.939 n=20+15)
    UncompressTwain-8       184B ± 0%      184B ± 0%     ~     (all equal)
    UncompressRand-8        186B ± 1%      186B ± 1%     ~     (p=0.183 n=19+15)
    
    name                old allocs/op  new allocs/op  delta
    Uncompress-8            0.00           0.00          ~     (all equal)
    UncompressPg1661-8      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
    UncompressDigits-8      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
    UncompressTwain-8       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
    UncompressRand-8        4.00 ± 0%      4.00 ± 0%     ~     (all equal)
    
    name                old speed      new speed      delta
    UncompressPg1661-8  1.05GB/s ± 1%  1.27GB/s ± 1%  +20.99%  (p=0.000 n=20+15)
    UncompressDigits-8  1.84GB/s ± 1%  1.99GB/s ± 2%   +8.31%  (p=0.000 n=20+15)
    UncompressTwain-8   1.09GB/s ± 1%  1.31GB/s ± 1%  +20.12%  (p=0.000 n=19+13)
    UncompressRand-8    3.89GB/s ± 2%  3.92GB/s ± 1%     ~     (p=0.056 n=20+14)