### PR TITLE
Overflow checks and alignment fix

### DIFF
--- a/internal/lz4block/decode_arm.s
+++ b/internal/lz4block/decode_arm.s
@@ -98,14 +98,15 @@ copyLiteralLoopCond:
 
 copyLiteralFinish:
 	// Copy remaining 0-3 bytes.
-	TST        $2, len
-	MOVHU.NE.P 2(src), tmp2
-	MOVB.NE.P  tmp2, 1(dst)
-	MOVW.NE    tmp2 >> 8, tmp1
-	MOVB.NE.P  tmp1, 1(dst)
-	TST        $1, len
-	MOVBU.NE.P 1(src), tmp3
-	MOVB.NE.P  tmp3, 1(dst)
+	// At this point, len may be < 0, but len&3 is still accurate.
+	TST       $1, len
+	MOVB.NE.P 1(src), tmp3
+	MOVB.NE.P tmp3, 1(dst)
+	TST       $2, len
+	MOVB.NE.P 2(src), tmp1
+	MOVB.NE.P tmp1, 2(dst)
+	MOVB.NE   -1(src), tmp2
+	MOVB.NE   tmp2, -1(dst)
 
 copyLiteralDone:
 	CMP src, srcend

--- a/internal/lz4block/decode_arm.s
+++ b/internal/lz4block/decode_arm.s
@@ -44,7 +44,8 @@ readLitlenLoop:
 	CMP     src, srcend
 	BEQ     shortSrc
 	MOVBU.P 1(src), tmp1
-	ADD     tmp1, len
+	ADD.S   tmp1, len
+	BVS     shortDst
 	CMP     $255, tmp1
 	BEQ     readLitlenLoop
 
@@ -130,7 +131,8 @@ readMatchlenLoop:
 	CMP     src, srcend
 	BEQ     shortSrc
 	MOVBU.P 1(src), tmp1
-	ADD     tmp1, len
+	ADD.S   tmp1, len
+	BVS     shortDst
 	CMP     $255, tmp1
 	BEQ     readMatchlenLoop
 

--- a/internal/lz4block/decode_arm.s
+++ b/internal/lz4block/decode_arm.s
@@ -54,12 +54,13 @@ readLitlenDone:
 	BEQ copyLiteralDone
 
 	// Bounds check dst+len and src+len.
-	ADD    dst, len, tmp1
-	CMP    dstend, tmp1
-	//BHI  shortDst	// Uncomment for distinct error codes.
-	ADD    src, len, tmp2
-	CMP.LS srcend, tmp2
-	BHI    shortSrc
+	ADD.S    dst, len, tmp1
+	ADD.CC.S src, len, tmp2
+	BCS      shortSrc
+	CMP      dstend, tmp1
+	//BHI    shortDst // Uncomment for distinct error codes.
+	CMP.LS   srcend, tmp2
+	BHI      shortSrc
 
 	// Copy literal.
 	CMP $4, len
@@ -115,7 +116,8 @@ copyLiteralDone:
 	AND $15, token, len
 
 	// Read offset.
-	ADD   $2, src
+	ADD.S $2, src
+	BCS   shortSrc
 	CMP   srcend, src
 	BHI   shortSrc
 	MOVBU -2(src), offset

--- a/internal/lz4block/decode_other.go
+++ b/internal/lz4block/decode_other.go
@@ -54,12 +54,16 @@ func decodeBlockGo(dst, src, dict []byte) (ret int) {
 					}
 				}
 			case lLen == 0xF:
-				for src[si] == 0xFF {
-					lLen += 0xFF
+				for {
+					x := uint(src[si])
+					if lLen += x; int(lLen) < 0 {
+						return hasError
+					}
 					si++
+					if x != 0xFF {
+						break
+					}
 				}
-				lLen += uint(src[si])
-				si++
 				fallthrough
 			default:
 				copy(dst[di:di+lLen], src[si:si+lLen])
@@ -80,16 +84,19 @@ func decodeBlockGo(dst, src, dict []byte) (ret int) {
 		si += 2
 
 		// Match.
-		mLen := b & 0xF
-		if mLen == 0xF {
-			for src[si] == 0xFF {
-				mLen += 0xFF
+		mLen := minMatch + b&0xF
+		if mLen == minMatch+0xF {
+			for {
+				x := uint(src[si])
+				if mLen += x; int(mLen) < 0 {
+					return hasError
+				}
 				si++
+				if x != 0xFF {
+					break
+				}
 			}
-			mLen += uint(src[si])
-			si++
 		}
-		mLen += minMatch
 
 		// Copy the match.
 		if di < offset {


### PR DESCRIPTION
This adds multiple missing overflow checks to the portable and ARM decoders, as well as fixing an alignment issue in the latter.

The check for literal/match length overflow hasn't been added to the amd64 decoder, because the overflow isn't triggered for blocks < 32PiB. AFAIK, no amd64 even has the physical address space for that much memory.