### PR TITLE
Restore R14+R15 after all memmove calls in amd64 decoder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ["1.14", "1.15"]
+        go: ["1.15", "1.16", "1.17"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/internal/lz4block/decode_amd64.s
+++ b/internal/lz4block/decode_amd64.s
@@ -203,6 +203,9 @@ memmove_lit:
 	ADDQ dst_len+8(FP), R8
 	MOVQ src_base+24(FP), R9
 	ADDQ src_len+32(FP), R9
+	MOVQ dict_base+48(FP), R14
+	MOVQ dict_len+56(FP), R15
+	ADDQ R14, R15
 	MOVQ R8, R12
 	SUBQ $32, R12
 	MOVQ R9, R13


### PR DESCRIPTION
Fixes #136. Updated GH actions to run on 1.15-1.17.