### PR TITLE
Updated example:

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -35,7 +35,7 @@ func Example() {
 func ExampleCompressBlock() {
 	s := "hello world"
 	data := []byte(strings.Repeat(s, 100))
-	buf := make([]byte, len(data))
+	buf := make([]byte, lz4.CompressBlockBound(len(data)))
 
 	var c lz4.Compressor
 	n, err := c.CompressBlock(data, buf)


### PR DESCRIPTION
changed the length of buffer to CompressBlockBound func to determine the buffer size so that the code can be used to determine buffer length for any length of string (compressible and incompressible). This will make  new users easier to copy and paste from the example code to their code.