### PR TITLE
internal/lz4block: Handle empty buffer in amd64 decoder

### DIFF
--- a/internal/lz4block/decode_amd64.s
+++ b/internal/lz4block/decode_amd64.s
@@ -58,6 +58,7 @@ loop:
 	// CX = lit_len
 	MOVQ DX, CX
 	SHRQ $4, CX
+	JZ   finish_lit_copy
 
 	// if lit_len != 0xF
 	CMPQ CX, $0xF
@@ -125,9 +126,6 @@ loop:
 	JMP loop
 
 lit_len_loop_pre:
-	// if lit_len > 0
-	CMPQ CX, $0
-	JEQ offset
 	CMPQ CX, $0xF
 	JNE copy_literal
 

--- a/internal/lz4block/decode_test.go
+++ b/internal/lz4block/decode_test.go
@@ -81,6 +81,11 @@ func TestBlockDecode(t *testing.T) {
 			[]byte{},
 		},
 		{
+			"empty_input_nil_dst",
+			[]byte{0},
+			nil,
+		},
+		{
 			"literal_only_short",
 			emitSeq("hello", 0, 0),
 			[]byte("hello"),


### PR DESCRIPTION
Fixes #163. The test for this is currently to run

```
go test ./internal/lz4block -run=TestBlockDecode/empty_input -v
```

and check that no -2 occurs in the output. I can add a separate test, but if #160 is resolved by allowing some not-quite-valid inputs (#165), that's not necessary.