### PR TITLE
Permit some invalid inputs in portable decoder

### DIFF
--- a/internal/lz4block/decode_amd64.s
+++ b/internal/lz4block/decode_amd64.s
@@ -58,6 +58,7 @@ loop:
 	// CX = lit_len
 	MOVQ DX, CX
 	SHRQ $4, CX
+	JZ   finish_lit_copy
 
 	// if lit_len != 0xF
 	CMPQ CX, $0xF
@@ -125,9 +126,6 @@ loop:
 	JMP loop
 
 lit_len_loop_pre:
-	// if lit_len > 0
-	CMPQ CX, $0
-	JEQ offset
 	CMPQ CX, $0xF
 	JNE copy_literal
 

--- a/internal/lz4block/decode_test.go
+++ b/internal/lz4block/decode_test.go
@@ -81,6 +81,11 @@ func TestBlockDecode(t *testing.T) {
 			[]byte{},
 		},
 		{
+			"empty_input_nil_dst",
+			[]byte{0},
+			nil,
+		},
+		{
 			"literal_only_short",
 			emitSeq("hello", 0, 0),
 			[]byte("hello"),

--- a/internal/lz4block/decode_test.go
+++ b/internal/lz4block/decode_test.go
@@ -131,8 +131,8 @@ func TestBlockDecode(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			buf := make([]byte, len(test.exp))
 			n := decodeBlock(buf, test.src, nil)
-			if n < 0 {
-				t.Log(n)
+			if n != len(test.exp) {
+				t.Errorf("expected %d, got %d", len(test.exp), n)
 			}
 			if !bytes.Equal(buf, test.exp) {
 				t.Fatalf("expected %q got %q", test.exp, buf)


### PR DESCRIPTION
Proposed solution to #160.

Inputs that violate the [end of block restrictions](https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md#end-of-block-restrictions) are now permitted in the portable decoder, so that UncompressBlock (and its companion WithDict) is now consistent across platforms and build tags. The asm decoders already allow these inputs and TestBlockDecode relied on them producing the right output, even when an error was returned.

Admittedly, this makes it harder to test the compression functions, which should never produce output that violates the end of block restrictions.

Includes #164, because without that patch, the amd64 decoder fails on the stricter test.