### PR TITLE
Fix performance regression in amd64 decoder

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -26,10 +26,10 @@ func BenchmarkCompress(b *testing.B) {
 }
 
 func BenchmarkCompressRandom(b *testing.B) {
-	buf := make([]byte, len(randomLZ4))
+	buf := make([]byte, lz4.CompressBlockBound(len(random)))
 	var c lz4.Compressor
 
-	n, _ := c.CompressBlock(pg1661, buf)
+	n, _ := c.CompressBlock(random, buf)
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(random)))

--- a/internal/lz4block/decode_test.go
+++ b/internal/lz4block/decode_test.go
@@ -155,6 +155,18 @@ func TestDecodeBlockInvalid(t *testing.T) {
 			100,
 		},
 		{
+			// A string of zeros could be interpreted as empty match+empty literal repeated,
+			// but only the last block may have an empty match (with the offset missing).
+			"repeated_zero_few",
+			string(make([]byte, 6)),
+			100,
+		},
+		{
+			"repeated_zero_many",
+			string(make([]byte, 100)),
+			100,
+		},
+		{
 			"final_lit_too_short",
 			"\x20a", // litlen = 2 but only a single-byte literal
 			100,


### PR DESCRIPTION
In the fix for #163, I accidentally rerouted matches without literals through the slow match copy path. This undoes the mistake, with the additional optimization of using 32-bit instructions where possible, to counter some slowdown in BenchmarkUncompressDigits.

Compared to 257c664d416bd8deace75610eedccf6504312315:

    name                old speed      new speed      delta
    UncompressPg1661-8  1.19GB/s ± 1%  1.19GB/s ± 1%    ~     (p=0.198 n=10+20)
    UncompressDigits-8  2.33GB/s ± 1%  2.38GB/s ± 1%  +2.14%  (p=0.000 n=10+19)
    UncompressTwain-8   1.22GB/s ± 1%  1.23GB/s ± 1%  +0.46%  (p=0.015 n=10+20)
    UncompressRand-8    3.89GB/s ± 2%  3.88GB/s ± 2%    ~     (p=0.923 n=10+12)

Compared to 947bcf2cb7b335de36ac19425f9dbe257f85d38c:

    name                old speed      new speed      delta
    UncompressPg1661-8   758MB/s ± 1%  1189MB/s ± 1%  +56.76%  (p=0.000 n=10+20)
    UncompressDigits-8  2.32GB/s ± 2%  2.38GB/s ± 1%   +2.65%  (p=0.000 n=10+19)
    UncompressTwain-8    812MB/s ± 1%  1227MB/s ± 1%  +51.20%  (p=0.000 n=10+20)
    UncompressRand-8    3.90GB/s ± 2%  3.87GB/s ± 2%     ~     (p=0.062 n=9+20)

Also includes a fix to a benchmark.