### PR TITLE
internal/lz4block: Faster table reset

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -26,10 +26,10 @@ func BenchmarkCompress(b *testing.B) {
 }
 
 func BenchmarkCompressRandom(b *testing.B) {
-	buf := make([]byte, len(randomLZ4))
+	buf := make([]byte, lz4.CompressBlockBound(len(random)))
 	var c lz4.Compressor
 
-	n, _ := c.CompressBlock(pg1661, buf)
+	n, _ := c.CompressBlock(random, buf)
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(random)))

--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -63,7 +63,10 @@ type Compressor struct {
 	// inspecting the input stream.
 	table [htSize]uint16
 
-	needsReset bool
+	// Bitmap indicating which positions in the table are in use.
+	// This allows us to quickly reset the table for reuse,
+	// without having to zero everything.
+	inUse [htSize / 32]uint32
 }
 
 // Get returns the position of a presumptive match for the hash h.
@@ -71,7 +74,10 @@ type Compressor struct {
 // If si < winSize, the return value may be negative.
 func (c *Compressor) get(h uint32, si int) int {
 	h &= htSize - 1
-	i := int(c.table[h])
+	i := 0
+	if c.inUse[h/32]&(1<<(h%32)) != 0 {
+		i = int(c.table[h])
+	}
 	i += si &^ winMask
 	if i >= si {
 		// Try previous 64kiB block (negative when in first block).
@@ -83,7 +89,10 @@ func (c *Compressor) get(h uint32, si int) int {
 func (c *Compressor) put(h uint32, si int) {
 	h &= htSize - 1
 	c.table[h] = uint16(si)
+	c.inUse[h/32] |= 1 << (h % 32)
 }
+
+func (c *Compressor) reset() { c.inUse = [htSize / 32]uint32{} }
 
 var compressorPool = sync.Pool{New: func() interface{} { return new(Compressor) }}
 
@@ -95,11 +104,8 @@ func CompressBlock(src, dst []byte) (int, error) {
 }
 
 func (c *Compressor) CompressBlock(src, dst []byte) (int, error) {
-	if c.needsReset {
-		// Zero out reused table to avoid non-deterministic output (issue #65).
-		c.table = [htSize]uint16{}
-	}
-	c.needsReset = true // Only false on first call.
+	// Zero out reused table to avoid non-deterministic output (issue #65).
+	c.reset()
 
 	// Return 0, nil only if the destination buffer size is < CompressBlockBound.
 	isNotCompressible := len(dst) < CompressBlockBound(len(src))


### PR DESCRIPTION
Zeroing out the 128kiB hash table takes a considerable amount of time in repeated calls to CompressBlock on small, poorly compressible blocks. Give the hashtable an 8kiB bitmap indicating which entries are in use and zero that out instead.
    
Linux/amd64, Go 1.17:

    name              old speed      new speed      delta
    CompressRandom-8  1.58GB/s ± 2%  1.94GB/s ± 2%  +23.44%  (p=0.000 n=20+19)
    CompressPg1661-8   826MB/s ± 5%   837MB/s ± 2%     ~     (p=0.101 n=19+20)
    CompressDigits-8   151MB/s ± 1%   150MB/s ± 2%   -0.73%  (p=0.012 n=20+20)
    CompressTwain-8    558MB/s ± 2%   559MB/s ± 2%     ~     (p=1.000 n=20+20)
    CompressRand-8    25.1MB/s ± 2%  25.1MB/s ± 3%     ~     (p=1.000 n=20+20)

Go 1.18beta:

    name              old speed      new speed      delta
    CompressRandom-8  1.58GB/s ± 1%  1.95GB/s ± 1%  +23.66%  (p=0.000 n=19+19)
    CompressPg1661-8   765MB/s ± 4%   764MB/s ± 6%     ~     (p=0.678 n=20+20)
    CompressDigits-8   139MB/s ± 5%   137MB/s ± 5%     ~     (p=0.204 n=20+20)
    CompressTwain-8    532MB/s ± 4%   526MB/s ± 6%     ~     (p=0.283 n=19+20)
    CompressRand-8    21.1MB/s ± 4%  21.2MB/s ± 7%     ~     (p=0.635 n=20+20)

(I'm not sure why 1.18 is slower than 1.17 overall.)