### PR TITLE
Decoder improvements

### DIFF
--- a/internal/lz4block/decode_amd64.s
+++ b/internal/lz4block/decode_amd64.s
@@ -89,6 +89,8 @@ loop:
 	// If it doesn't work out, the info won't be wasted.
 	// offset := uint16(data[:2])
 	MOVWLZX (SI), DX
+	TESTL DX, DX
+	JE err_corrupt
 	ADDQ $2, SI
 	JC err_short_buf
 

--- a/internal/lz4block/decode_arm.s
+++ b/internal/lz4block/decode_arm.s
@@ -110,12 +110,12 @@ copyLiteralFinish:
 	MOVB.NE   tmp2, -1(dst)
 
 copyLiteralDone:
-	CMP src, srcend
-	BEQ end
-
 	// Initial part of match length.
 	// This frees up the token register for reuse as offset.
 	AND $15, token, len
+
+	CMP src, srcend
+	BEQ end
 
 	// Read offset.
 	ADD.S $2, src
@@ -213,6 +213,8 @@ copyMatchDone:
 	BNE loop
 
 end:
+	CMP  $0, len
+	BNE  corrupt
 	SUB  dstorig, dst, tmp1
 	MOVW tmp1, ret+36(FP)
 	RET

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -118,6 +118,9 @@ copyLiteralShortEnd:
 	MOVB.P  tmp4, 1(dst)
 
 copyLiteralDone:
+	// Initial part of match length.
+	AND $15, token, len
+
 	CMP src, srcend
 	BEQ end
 
@@ -129,8 +132,7 @@ copyLiteralDone:
 	MOVHU -2(src), offset
 	CBZ   offset, corrupt
 
-	// Read match length.
-	AND $15, token, len
+	// Read rest of match length.
 	CMP $15, len
 	BNE readMatchlenDone
 
@@ -195,6 +197,7 @@ copyMatchLoop8:
 
 	MOVD (match)(len), tmp2 // match+len == match+lenRem-8.
 	ADD  lenRem, dst
+	MOVD $0, len
 	MOVD tmp2, -8(dst)
 	B    copyMatchDone
 
@@ -210,6 +213,7 @@ copyMatchDone:
 	BNE loop
 
 end:
+	CBNZ len, corrupt
 	SUB  dstorig, dst, tmp1
 	MOVD tmp1, ret+72(FP)
 	RET

--- a/internal/lz4block/decode_asm.go
+++ b/internal/lz4block/decode_asm.go
@@ -1,3 +1,4 @@
+//go:build (amd64 || arm || arm64) && !appengine && gc && !noasm
 // +build amd64 arm arm64
 // +build !appengine
 // +build gc

--- a/internal/lz4block/decode_other.go
+++ b/internal/lz4block/decode_other.go
@@ -73,9 +73,11 @@ func decodeBlock(dst, src, dict []byte) (ret int) {
 				di += lLen
 			}
 		}
-		if si == uint(len(src)) {
+
+		mLen := b & 0xF
+		if si == uint(len(src)) && mLen == 0 {
 			break
-		} else if si > uint(len(src)) {
+		} else if si >= uint(len(src)) {
 			return hasError
 		}
 
@@ -86,7 +88,7 @@ func decodeBlock(dst, src, dict []byte) (ret int) {
 		si += 2
 
 		// Match.
-		mLen := minMatch + b&0xF
+		mLen += minMatch
 		if mLen == minMatch+0xF {
 			for {
 				x := uint(src[si])

--- a/internal/lz4block/decode_test.go
+++ b/internal/lz4block/decode_test.go
@@ -198,6 +198,12 @@ func TestDecodeBlockInvalid(t *testing.T) {
 			"\x000000",
 			10,
 		},
+		{
+			// Zero offset in a short literal.
+			"zero_offset",
+			"\xe1abcdefghijklmn\x00\x00\xe0abcdefghijklmn",
+			40,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dst := make([]byte, test.size+8)

--- a/internal/lz4block/decode_test.go
+++ b/internal/lz4block/decode_test.go
@@ -101,6 +101,11 @@ func TestBlockDecode(t *testing.T) {
 			bytes.Repeat([]byte("A"), 15),
 		},
 		{
+			"literal_only_long_2",
+			emitSeq(strings.Repeat("A", 16), 0, 0),
+			bytes.Repeat([]byte("A"), 16),
+		},
+		{
 			"repeat_match_len",
 			emitSeq("a", 1, 4),
 			[]byte("aaaaa"),
@@ -114,6 +119,13 @@ func TestBlockDecode(t *testing.T) {
 			"long_match",
 			emitSeq("A", 1, 16),
 			bytes.Repeat([]byte("A"), 17),
+		},
+		{
+			// Triggers a case in the amd64 decoder where its last action
+			// is a call to runtime.memmove.
+			"memmove_last",
+			emitSeq(strings.Repeat("ABCD", 20), 80, 60),
+			bytes.Repeat([]byte("ABCD"), 36)[:140],
 		},
 		{
 			"repeat_match_log_len_2_seq",
@@ -170,6 +182,11 @@ func TestDecodeBlockInvalid(t *testing.T) {
 			"final_lit_too_short",
 			"\x20a", // litlen = 2 but only a single-byte literal
 			100,
+		},
+		{
+			"no_space_for_offset",
+			"\x01", // mLen > 0 but no following offset.
+			10,
 		},
 		{
 			"write_beyond_len_dst",


### PR DESCRIPTION
* Handles a corner case in the decoders that wasn't previously detected, where the last token declared a match but input stopped right where the match offset would be.
* amd64 decoder now checks for zero offsets in its shortcut code, making it consistent with the other decoders.
* arm64 decoder has been made a few instructions shorter and it can use its fast match copy loop even after copying from a dictionary, just like the other decoders.