### PR TITLE
Fix Reader.Reset() docs

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -196,10 +196,8 @@ func (r *Reader) read(buf []byte) (int, error) {
 }
 
 // Reset clears the state of the Reader r such that it is equivalent to its
-// initial state from NewReader, but instead writing to writer.
+// initial state from NewReader, but instead reading from reader.
 // No access to reader is performed.
-//
-// w.Close must be called before Reset.
 func (r *Reader) Reset(reader io.Reader) {
 	if r.data != nil {
 		lz4block.Put(r.data)


### PR DESCRIPTION
I'm using your library to add LZ4 decompression support to my 7-Zip library, I noticed this small typo in the docs. There is no `Reader.Close()` method so I just removed that line entirely.