### PR TITLE
do not auto-Close() Writer after ReadFrom()/Copy()

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -234,6 +234,5 @@ func (w *Writer) ReadFrom(r io.Reader) (n int64, err error) {
 			data = size.Get()
 		}
 	}
-	err = w.Close()
 	return
 }


### PR DESCRIPTION
ReadFrom()/Copy() should leave it to user whether or not to Close() afterwards rather than shutting down/flushing immediately after the buffer is copied in.

fixes #183