### PR TITLE
remove state change after Flush

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -153,7 +153,7 @@ func (w *Writer) Flush() (err error) {
 	default:
 		return nil
 	}
-	defer w.state.nextd(&err)
+
 	if w.idx > 0 {
 		// Flush pending data, disable w.data freeing as it is done later on.
 		if err = w.write(w.data[:w.idx], false); err != nil {


### PR DESCRIPTION
A call do Flush does not necessarily mean that the state should change.  Another write could come in, if the state is closed this can't occur.  Another Write can come in, it just needs to be a new block.

Closes #187 

Test Code:

```
package main

import (
	"bytes"
	"fmt"

	lz4 "github.com/pierrec/lz4/v4"
)

func main() {
	var dst bytes.Buffer

	zw := lz4.NewWriter(&dst)
	n, err := zw.Write([]byte("a"))
	fmt.Printf("First Write: n: %d, err: %v\n", n, err)
	fmt.Printf("dst after first Write(): %v\n", dst.Bytes())
	zw.Flush()
	fmt.Printf("dst after Flush(): %v\n", dst.Bytes())
	n, err = zw.Write([]byte("b"))
	fmt.Printf("Second Write: n: %d, err: %v\n", n, err)
	fmt.Printf("dst after second Write(): %v\n", dst.Bytes())
	zw.Close()
	fmt.Printf("dst after Close(): %v\n", dst.Bytes())
}
```

Before fix:

```
First Write: n: 1, err: <nil>
dst after first Write(): [4 34 77 24 100 112 185]
dst after Flush(): [4 34 77 24 100 112 185 1 0 0 128 97]
Second Write: n: 0, err: <nil>
dst after second Write(): [4 34 77 24 100 112 185 1 0 0 128 97]
dst after Close(): [4 34 77 24 100 112 185 1 0 0 128 97 0 0 0 0 86 116 13 85]
```

After fix:

```
First Write: n: 1, err: <nil>
dst after first Write(): [4 34 77 24 100 112 185]
dst after Flush(): [4 34 77 24 100 112 185 1 0 0 128 97]
Second Write: n: 1, err: <nil>
dst after second Write(): [4 34 77 24 100 112 185 1 0 0 128 97]
dst after Close(): [4 34 77 24 100 112 185 1 0 0 128 97 1 0 0 128 98 0 0 0 0 83 252 153 73]
```
