### PR TITLE
Restore fix for #51, but in a different form

### DIFF
--- a/internal/lz4block/decode_other.go
+++ b/internal/lz4block/decode_other.go
@@ -48,11 +48,14 @@ func decodeBlock(dst, src, dict []byte) (ret int) {
 					mLen += 4
 					if offset := u16(src[si:]); mLen <= offset && offset < di {
 						i := di - offset
-						end := i + 18
-						copy(dst[di:], dst[i:end])
-						si += 2
-						di += mLen
-						continue
+						// The remaining buffer may not hold 18 bytes.
+						// See https://github.com/pierrec/lz4/issues/51.
+						if end := i + 18; end <= uint(len(dst)) {
+							copy(dst[di:], dst[i:end])
+							si += 2
+							di += mLen
+							continue
+						}
 					}
 				}
 			case lLen == 0xF:


### PR DESCRIPTION
The check for end > len(dst) was removed to fix #167, but this caused a new bug, #189. It's restored in a form that avoids both.

<del>Also closes #191, which is included with a small change, s/os.ReadFile/ioutil.ReadFile/g, to support older Go versions.</del>

Should fix syncthing/syncthing#8484.