### PR TITLE
Use better appropriate 5 byte hash function

### DIFF
--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -33,9 +33,15 @@ func recoverBlock(e *error) {
 
 // blockHash hashes the lower five bytes of x into a value < htSize.
 func blockHash(x uint64) uint32 {
-	const prime6bytes = 227718039650203
-	x &= 1<<40 - 1
-	return uint32((x * prime6bytes) >> (64 - hashLog))
+	if true {
+		// Create hash from 5 bytes.
+		const prime5bytes = 889523592379
+		return uint32(((x << (64 - 40)) * prime5bytes) >> (64 - hashLog))
+	} else {
+		// Create hash from 6 bytes.
+		const prime6bytes = 227718039650203
+		return uint32(((x << (64 - 48)) * prime6bytes) >> (64 - hashLog))
+	}
 }
 
 func CompressBlockBound(n int) int {


### PR DESCRIPTION
#130 uses a suboptimal hashing function, with more collisions than needed. This uses an appropriate prime and uses the upper part for the multiplication.

Change in compression:

enwik9: 455570711 -> 454825169
github-june-2days-2019.json: 1280413313 -> 1278906810

[here](https://github.com/klauspost/compress/blob/3909335c441d115103e37728040269eae87df317/zstd/hash.go#L20) are implementations for different lengths, from zstandard.

Switching from 6 to 5 has regressions, and generally isn't better for the fastest option.

While it may sometimes improve compression it also causes smaller matches to be found, generally making decompression slower.

But I will not go into a longer argument about it here, but I left the 6 byte matching code with a bool toggle.