### PR TITLE
Revert "Hash five bytes instead of six"

### DIFF
--- a/internal/lz4block/block.go
+++ b/internal/lz4block/block.go
@@ -31,11 +31,10 @@ func recoverBlock(e *error) {
 	}
 }
 
-// blockHash hashes the lower five bytes of x into a value < htSize.
+// blockHash hashes the lower 6 bytes into a value < htSize.
 func blockHash(x uint64) uint32 {
 	const prime6bytes = 227718039650203
-	x &= 1<<40 - 1
-	return uint32((x * prime6bytes) >> (64 - hashLog))
+	return uint32(((x << (64 - 48)) * prime6bytes) >> (64 - hashLog))
 }
 
 func CompressBlockBound(n int) int {
@@ -123,9 +122,9 @@ func (c *Compressor) CompressBlock(src, dst []byte) (int, error) {
 		goto lastLiterals
 	}
 
-	// Fast scan strategy: the hash table only stores the last five-byte sequences.
+	// Fast scan strategy: the hash table only stores the last 4 bytes sequences.
 	for si < sn {
-		// Hash the next five bytes (sequence)...
+		// Hash the next 6 bytes (sequence)...
 		match := binary.LittleEndian.Uint64(src[si:])
 		h := blockHash(match)
 		h2 := blockHash(match >> 8)


### PR DESCRIPTION
This reverts commit dff8cbc7b3b0fd8dbab7f517327f59388c1b25fd.

According to @klauspost's research, this doesn't necessarily produce smaller output and decompression speed suffers quite a bit. Closes #196, see discussion there.