### PR TITLE
Add lz4.AppendOption for NewWriter

### DIFF
--- a/options.go
+++ b/options.go
@@ -92,6 +92,23 @@ func ChecksumOption(flag bool) Option {
 	}
 }
 
+// AppendOption  if appendToLz4File = true ,then will not write header
+func AppendOption(appendToLz4File bool) Option {
+	return func(a applier) error {
+		switch w := a.(type) {
+		case nil:
+			s := fmt.Sprintf("AppendOption(%v)", appendToLz4File)
+			return lz4errors.Error(s)
+		case *Writer:
+			if appendToLz4File {
+				w.frame.Descriptor.Checksum = 1
+			}
+			return nil
+		}
+		return lz4errors.ErrOptionNotApplicable
+	}
+}
+
 // SizeOption sets the size of the original uncompressed data (default=0). It is useful to know the size of the
 // whole uncompressed data stream.
 func SizeOption(size uint64) Option {


### PR DESCRIPTION
Add lz4.AppendOption, if NewWriter set lz4.AppendOption(true) ,then will not write header.

In this way, you can continue to write new data on the existing lz4 file.

like this:

```
        // 
	fw, _ := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0644)
	w := lz4.NewWriter(fw)

	w.Apply(lz4.ChecksumOption(false))

	w.Write(d)
	w.Flush()

        // do some other  thing, or a long time later

        
	fw, _ := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0644)
	w := lz4.NewWriter(fw)

	w.Apply(lz4.ChecksumOption(false), lz4.AppendOption(true))

	w.Write(d)
	w.Flush()


```

Thank
