### PR TITLE
[reader] optimize hot Reader.Read() path

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -101,7 +101,13 @@ func (r *Reader) init() error {
 }
 
 func (r *Reader) Read(buf []byte) (n int, err error) {
-	defer r.state.check(&err)
+	defer func() {
+		// Inlines a nil check to reduce function call overhead on hot path.
+		// Only set up fn call and stack-pass arg if err != nil.
+		if err != nil {
+			r.state.check(&err)
+		}
+	}()
 	switch r.state.state {
 	case readState:
 	case closedState, errorState:


### PR DESCRIPTION
See https://gist.github.com/lizthegrey/0ce7f8cd4a70ecedb5c299dfc0332976 for full disassembly

```
    103       19.10s     19.25s           func (r *Reader) Read(buf []byte) (n int, err error) { 
    104          39s     39.31s           	defer r.state.check(&err) 
[...]
    156       31.14s     59.20s           	return 
```

A huge amount of call overhead is incurred running the defer state.check() that can be avoided on nil err.