### PR TITLE
Restore copyMatchTry4

### DIFF
--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -185,7 +185,7 @@ copyMatchTry8:
 	// A 16-at-a-time loop doesn't provide a further speedup.
 	CMP  $8, len
 	CCMP HS, offset, $8, $0
-	BLO  copyMatchLoop1
+	BLO  copyMatchTry4
 
 	AND    $7, len, lenRem
 	SUB    $8, len
@@ -201,8 +201,19 @@ copyMatchLoop8:
 	MOVD tmp2, -8(dst)
 	B    copyMatchDone
 
+copyMatchTry4:
+	// Copy words if both len and offset are at least four.
+	CMP  $4, len
+	CCMP HS, offset, $4, $0
+	BLO  copyMatchLoop1
+
+	MOVWU.P 4(match), tmp2
+	MOVWU.P tmp2, 4(dst)
+	SUBS    $4, len
+	BEQ     copyMatchDone
+
 copyMatchLoop1:
-	// Byte-at-a-time copy for small offsets.
+	// Byte-at-a-time copy for small offsets <= 3.
 	MOVBU.P 1(match), tmp2
 	MOVB.P  tmp2, 1(dst)
 	SUBS    $1, len


### PR DESCRIPTION
Fixes #205 

cortex a72:
```
benchmark                        old ns/op     new ns/op     delta
BenchmarkUncompress-16           20.8          20.8          +0.00%
BenchmarkUncompressPg1661-16     1702946       1585558       -6.89%
BenchmarkUncompressDigits-16     124267        111448        -10.32%
BenchmarkUncompressTwain-16      1177542       1002623       -14.85%
BenchmarkUncompressRand-16       9120          9116          -0.04%

benchmark                        old MB/s     new MB/s     speedup
BenchmarkUncompressPg1661-16     221.60       238.00       1.07x
BenchmarkUncompressDigits-16     766.77       854.96       1.12x
BenchmarkUncompressTwain-16      217.74       255.73       1.17x
BenchmarkUncompressRand-16       1798.55      1799.46      1.00x

benchmark                        old allocs     new allocs     delta
BenchmarkUncompress-16           0              0              +0.00%
BenchmarkUncompressPg1661-16     4              4              +0.00%
BenchmarkUncompressDigits-16     4              4              +0.00%
BenchmarkUncompressTwain-16      4              4              +0.00%
BenchmarkUncompressRand-16       4              4              +0.00%

benchmark                        old bytes     new bytes     delta
BenchmarkUncompress-16           0             0             +0.00%
BenchmarkUncompressPg1661-16     184           184           +0.00%
BenchmarkUncompressDigits-16     184           210           +14.13%
BenchmarkUncompressTwain-16      186           186           +0.00%
BenchmarkUncompressRand-16       187           186           -0.53%
```

ampere:
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkUncompress-4           8.84          8.86          +0.25%
BenchmarkUncompressPg1661-4     946111        910414        -3.77%
BenchmarkUncompressDigits-4     62239         60205         -3.27%
BenchmarkUncompressTwain-4      599464        576336        -3.86%
BenchmarkUncompressRand-4       4250          4485          +5.53%

benchmark                       old MB/s     new MB/s     speedup
BenchmarkUncompressPg1661-4     398.86       414.50       1.04x
BenchmarkUncompressDigits-4     1530.93      1582.66      1.03x
BenchmarkUncompressTwain-4      427.72       444.88       1.04x
BenchmarkUncompressRand-4       3859.74      3657.60      0.95x

benchmark                       old allocs     new allocs     delta
BenchmarkUncompress-4           0              0              +0.00%
BenchmarkUncompressPg1661-4     4              4              +0.00%
BenchmarkUncompressDigits-4     4              4              +0.00%
BenchmarkUncompressTwain-4      4              4              +0.00%
BenchmarkUncompressRand-4       4              4              +0.00%

benchmark                       old bytes     new bytes     delta
BenchmarkUncompress-4           0             0             +0.00%
BenchmarkUncompressPg1661-4     184           184           +0.00%
BenchmarkUncompressDigits-4     184           184           +0.00%
BenchmarkUncompressTwain-4      184           184           +0.00%
BenchmarkUncompressRand-4       184           184           +0.00%
```