### PR TITLE
Writer: initialize the writer on Flush() if wasn't initialized before

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -150,6 +150,10 @@ func (w *Writer) Flush() (err error) {
 	case writeState:
 	case errorState:
 		return w.state.err
+	case newState:
+		if err = w.init(); w.state.next(err) {
+			return
+		}
 	default:
 		return nil
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestWriter(t *testing.T) {
 	goldenFiles := []string{
+		"testdata/empty.txt",
 		"testdata/e.txt",
 		"testdata/gettysburg.txt",
 		"testdata/Mark.Twain-Tom.Sawyer.txt",
@@ -75,7 +76,7 @@ func TestWriter(t *testing.T) {
 					t.Errorf("invalid sizes: got %d; want %d", got, want)
 				}
 
-				if got, want := out.Bytes(), raw; !reflect.DeepEqual(got, want) {
+				if got, want := out.Bytes(), raw; !bytes.Equal(got, want) {
 					t.Fatal("uncompressed data does not match original")
 				}
 


### PR DESCRIPTION
This allows compressing empty files, because without this change the proper headers were not emitted when reading an empty file via e.g. `io.Copy()`.