### PR TITLE
Reverts bc1239ba, no longer needed to conform to legacy

### DIFF
--- a/internal/lz4block/blocks.go
+++ b/internal/lz4block/blocks.go
@@ -8,11 +8,8 @@ const (
 	Block256Kb
 	Block1Mb
 	Block4Mb
+	Block8Mb = 2 * Block4Mb
 )
-
-// In legacy mode all blocks are compressed regardless
-// of the compressed size: use the bound size.
-var Block8Mb = uint32(CompressBlockBound(8 << 20))
 
 var (
 	BlockPool64K  = sync.Pool{New: func() interface{} { return make([]byte, Block64Kb) }}

--- a/internal/lz4stream/block.go
+++ b/internal/lz4stream/block.go
@@ -224,9 +224,7 @@ func (b *FrameDataBlock) Close(f *Frame) {
 func (b *FrameDataBlock) Compress(f *Frame, src []byte, level lz4block.CompressionLevel) *FrameDataBlock {
 	data := b.data
 	if f.isLegacy() {
-		// In legacy mode, the buffer is sized according to CompressBlockBound,
-		// but only 8Mb is buffered for compression.
-		src = src[:8<<20]
+		data = data[:cap(data)]
 	} else {
 		data = data[:len(src)] // trigger the incompressible flag in CompressBlock
 	}


### PR DESCRIPTION
This fixes the tests and verifies that the fix from bc1239ba, which broke the tests, is no longer needed to conform to legacy compression.