### PR TITLE
fix: reset frame when read to EOF to release buffer in Block

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -84,6 +84,7 @@ var (
 	digitsLZ4 = mustLoadFile("testdata/e.txt.lz4")
 	twainLZ4  = mustLoadFile("testdata/Mark.Twain-Tom.Sawyer.txt.lz4")
 	randomLZ4 = mustLoadFile("testdata/random.data.lz4")
+	repeatLz4 = mustLoadFile("testdata/repeat.txt.lz4")
 )
 
 func benchmarkUncompress(b *testing.B, compressed []byte) {
@@ -158,5 +159,21 @@ func BenchmarkWriterReset(b *testing.B) {
 
 		_, _ = zw.Write(src)
 		_ = zw.Close()
+	}
+}
+
+func BenchmarkReaderNoReset(b *testing.B) {
+	compressed := repeatLz4
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r := bytes.NewReader(compressed)
+		zr := lz4.NewReader(r)
+		buf := bytes.NewBuffer(nil)
+		_, err := buf.ReadFrom(zr)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/reader.go
+++ b/reader.go
@@ -135,6 +135,8 @@ func (r *Reader) Read(buf []byte) (n int, err error) {
 				}
 				lz4block.Put(r.data)
 				r.data = nil
+				// reset frame to release the buffer held by Block
+				r.frame.Reset(r.num)
 				return
 			default:
 				return
@@ -157,9 +159,9 @@ func (r *Reader) Read(buf []byte) (n int, err error) {
 }
 
 // read uncompresses the next block as follow:
-// - if buf has enough room, the block is uncompressed into it directly
-//   and the lenght of used space is returned
-// - else, the uncompress data is stored in r.data and 0 is returned
+//   - if buf has enough room, the block is uncompressed into it directly
+//     and the lenght of used space is returned
+//   - else, the uncompress data is stored in r.data and 0 is returned
 func (r *Reader) read(buf []byte) (int, error) {
 	block := r.frame.Blocks.Block
 	_, err := block.Read(r.frame, r.src, r.cum)


### PR DESCRIPTION
We use reader to decompress with no pooling object, it's some code like:
```
func Decompress(compressed []byte) ([]byte, error) {
	if len(compressed) == 0 {
		return compressed, nil
	}
	destBuffer := bytes.Buffer{}
	bytesReader := bytes.NewReader(compressed)
	lz4Reader := lz4.NewReader(bytesReader)
	if _, err := destBuffer.ReadFrom(lz4Reader); err != nil {
		return nil, err
	}
	return destBuffer.Bytes(), nil
}
```
and we found a big performace regression when we upgrade to v4.1.21 (from v4.0.2), after some test we narrow down the change from v4.1.0 -> v4.1.1.

It's seems that the code do `BlockSizeIndex.Get()` twice and only call `Put()` to return the buffer 1 time.  It look like that the buffer from this stack is not released. 
```
lz4block.BlockSizeIndex.Get (blocks.go:54) github.com/pierrec/lz4/v4/internal/lz4block
lz4stream.NewFrameDataBlock (block.go:197) github.com/pierrec/lz4/v4/internal/lz4stream
lz4stream.(*Blocks).initR (block.go:99) github.com/pierrec/lz4/v4/internal/lz4stream
lz4stream.(*Frame).InitR (frame.go:114) github.com/pierrec/lz4/v4/internal/lz4stream
lz4.(*Reader).init (reader.go:91) github.com/pierrec/lz4/v4
lz4.(*Reader).Read (reader.go:111) github.com/pierrec/lz4/v4
bytes.(*Buffer).ReadFrom (buffer.go:211) bytes
```
So here i added a Reset when read to EOF, to release the underlying buffer in `Block`.
Added a Benchmark test:
```
Before:
BenchmarkReaderNoReset-12    	  258943	      4354 ns/op	   70309 B/op	      12 allocs/op

After:
BenchmarkReaderNoReset-12    	 1136524	      1031 ns/op	    4226 B/op	      11 allocs/op
```
