### PR TITLE
Fix WriteTo on a started Reader, and the resulting incorrect error message

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -214,6 +214,7 @@ func (r *Reader) Reset(reader io.Reader) {
 // WriteTo efficiently uncompresses the data from the Reader underlying source to w.
 func (r *Reader) WriteTo(w io.Writer) (n int64, err error) {
 	switch r.state.state {
+	case readState:
 	case closedState, errorState:
 		return 0, r.state.err
 	case newState:

--- a/reader_test.go
+++ b/reader_test.go
@@ -319,3 +319,31 @@ func TestValidFrameHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestReader_WriteTo(t *testing.T) {
+	data := pg1661LZ4
+	buf := new(bytes.Buffer)
+	src := bytes.NewReader(data)
+	zr := lz4.NewReader(src)
+
+	// Read header only
+	n, err := zr.Read(nil)
+	if err != nil {
+		t.Fatalf("error reading header: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expecting zero byte read, got %d bytes", n)
+	}
+
+	n64, err := zr.WriteTo(buf)
+	if err != nil {
+		t.Fatalf("error during WriteTo: %v", err)
+	}
+	if n64 != int64(len(pg1661)) {
+		t.Fatalf("expecting to read %d bytes, got %d", len(pg1661), n64)
+	}
+
+	if !reflect.DeepEqual(buf.Bytes(), pg1661) {
+		t.Fatal("result does not match original")
+	}
+}

--- a/state.go
+++ b/state.go
@@ -69,7 +69,7 @@ func (s *_State) check(errp *error) {
 }
 
 func (s *_State) fail() error {
-	s.state = errorState
 	s.err = fmt.Errorf("%w[%s]", lz4errors.ErrInternalUnhandledState, s.state)
+	s.state = errorState
 	return s.err
 }


### PR DESCRIPTION
This case comes up when we use r.Read(nil) to obtain the header only, and then later stream the content with io.Copy.