### PR TITLE
Eliminate interface-boxing allocations in blocks.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pierrec/lz4/v4
 
-go 1.14
+go 1.17

--- a/internal/lz4block/blocks_test.go
+++ b/internal/lz4block/blocks_test.go
@@ -1,0 +1,42 @@
+package lz4block
+
+import (
+	"testing"
+)
+
+func TestBlockGetPut(t *testing.T) {
+	expect := map[BlockSizeIndex]uint32{ // block index -> expected size
+		4: Block64Kb,
+		5: Block256Kb,
+		6: Block1Mb,
+		7: Block4Mb,
+		3: Block8Mb,
+	}
+	for idx, size := range expect {
+		buf := idx.Get()
+		if uint32(cap(buf)) != size {
+			t.Errorf("expected size %d for index %d, got %d", size, idx, cap(buf))
+		}
+		Put(buf) // ensure no panic
+	}
+}
+
+func TestBlockGetInvalid(t *testing.T) {
+	defer func() { recover() }() // swallow panic
+	_ = BlockSizeIndex(123).Get()
+	t.Fatalf("expected panic on bad Get")
+}
+
+func TestBlockPutInvalid(t *testing.T) {
+	defer func() { recover() }() // swallow panic
+	Put(make([]byte, 123))
+	t.Fatalf("expected panic on bad Put")
+}
+
+func BenchmarkGetPut(b *testing.B) {
+	const idx = BlockSizeIndex(4)
+	for i := 0; i < b.N; i++ {
+		buf := idx.Get()
+		Put(buf)
+	}
+}


### PR DESCRIPTION
`internal/lz4block/blocks.go` incurs an allocation on every call to `Put`, even when the pool is already expanded, because putting. a `[]byte` into an `interface{}` requires a heap allocation of the slice header. We can avoid this by using array pointers without changing the `Get` and `Put` function signatures.

This change does require Go 1.17 minimum. If this is an issue, I can make another version of this PR with build tags to conditionally use this new technique.

My first time contributing to this repo; open to any feedback!

Before 2nd commit on this branch:
```
$ go test -test.run='^$' -bench '.*' -benchmem github.com/pierrec/lz4/v4/internal/lz4block
goos: darwin
goarch: arm64
pkg: github.com/pierrec/lz4/v4/internal/lz4block
cpu: Apple M1 Pro
BenchmarkGetPut-10    	49272153	        24.25 ns/op	      24 B/op	       1 allocs/op
```
After 2nd commit:
```
$ go test -test.run='^$' -bench '.*' -benchmem github.com/pierrec/lz4/v4/internal/lz4block
goos: darwin
goarch: arm64
pkg: github.com/pierrec/lz4/v4/internal/lz4block
cpu: Apple M1 Pro
BenchmarkGetPut-10    	135518984	         8.707 ns/op	       0 B/op	       0 allocs/op
```