### PR TITLE
Fix broken tests

### DIFF
--- a/compressing_reader_test.go
+++ b/compressing_reader_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/pierrec/lz4/v4"
@@ -27,7 +26,6 @@ func TestCompressingReader(t *testing.T) {
 	for _, fname := range goldenFiles {
 		for _, option := range []lz4.Option{
 			lz4.BlockChecksumOption(true),
-			lz4.SizeOption(123),
 		} {
 			label := fmt.Sprintf("%s/%s", fname, option)
 			t.Run(label, func(t *testing.T) {
@@ -66,12 +64,6 @@ func TestCompressingReader(t *testing.T) {
 
 				if !bytes.Equal(out, raw) {
 					t.Fatal("uncompressed data does not match original")
-				}
-
-				if strings.Contains(option.String(), "SizeOption") {
-					if got, want := zr.Size(), 123; got != want {
-						t.Errorf("invalid sizes: got %d; want %d", got, want)
-					}
 				}
 			})
 		}

--- a/internal/lz4block/block_test.go
+++ b/internal/lz4block/block_test.go
@@ -1,10 +1,10 @@
-//+build go1.9
-
 package lz4block_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 
@@ -21,14 +21,14 @@ type testcase struct {
 
 var rawFiles = []testcase{
 	// {"testdata/207326ba-36f8-11e7-954a-aca46ba8ca73.png", true, nil},
-	{"../../testdata/e.txt", false, nil},
-	{"../../testdata/gettysburg.txt", true, nil},
-	{"../../testdata/Mark.Twain-Tom.Sawyer.txt", true, nil},
-	{"../../testdata/pg1661.txt", true, nil},
-	{"../../testdata/pi.txt", false, nil},
-	{"../../testdata/random.data", false, nil},
-	{"../../testdata/repeat.txt", true, nil},
-	{"../../testdata/pg1661.txt", true, nil},
+	{"../../testdata/e.txt.gz", false, nil},
+	{"../../testdata/gettysburg.txt.gz", true, nil},
+	{"../../testdata/Mark.Twain-Tom.Sawyer.txt.gz", true, nil},
+	{"../../testdata/pg1661.txt.gz", true, nil},
+	{"../../testdata/pi.txt.gz", false, nil},
+	{"../../testdata/random.data.gz", false, nil},
+	{"../../testdata/repeat.txt.gz", true, nil},
+	{"../../testdata/pg1661.txt.gz", true, nil},
 }
 
 func TestCompressUncompressBlock(t *testing.T) {
@@ -88,7 +88,7 @@ func TestCompressUncompressBlock(t *testing.T) {
 	}
 
 	for _, tc := range rawFiles {
-		src, err := os.ReadFile(tc.file)
+		src, err := readGz(tc.file)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -130,8 +130,8 @@ func TestCompressCornerCase_CopyDstUpperBound(t *testing.T) {
 		}
 	}
 
-	file := "../../testdata/upperbound.data"
-	src, err := os.ReadFile(file)
+	file := "../../testdata/upperbound.data.gz"
+	src, err := readGz(file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,4 +199,17 @@ func TestWriteLiteralLen(t *testing.T) {
 		dst := make([]byte, c.dstlen)
 		lz4block.CompressBlock([]byte(c.src), dst)
 	}
+}
+
+func readGz(fname string) ([]byte, error) {
+	file, err := os.Open(fname)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, err
+	}
+	return io.ReadAll(gzr)
 }

--- a/internal/lz4block/blocks.go
+++ b/internal/lz4block/blocks.go
@@ -82,6 +82,8 @@ func Put(buf []byte) {
 		blockPool4M.Put((*[Block4Mb]byte)(buf[:c]))
 	case Block8Mb:
 		blockPool8M.Put((*[Block8Mb]byte)(buf[:c]))
+	case 0:
+		// Allow "returning" an empty buffer.
 	default:
 		panic(fmt.Errorf("invalid block size %d", c))
 	}

--- a/reader.go
+++ b/reader.go
@@ -217,10 +217,8 @@ func (r *Reader) read(buf []byte) (int, error) {
 // initial state from NewReader, but instead reading from reader.
 // No access to reader is performed.
 func (r *Reader) Reset(reader io.Reader) {
-	if r.data != nil {
-		lz4block.Put(r.data)
-		r.data = nil
-	}
+	lz4block.Put(r.data)
+	r.data = nil
 	r.frame.Reset(r.num)
 	r.state.reset()
 	r.src = reader

--- a/reader.go
+++ b/reader.go
@@ -63,7 +63,7 @@ func (r *Reader) Apply(options ...Option) (err error) {
 	return
 }
 
-// Size returns the size of the underlying uncompressed data, if set in the stream.
+// Size returns the size of the current frame's uncompressed data, if set in the stream.
 func (r *Reader) Size() int {
 	switch r.state.state {
 	case readState, closedState:

--- a/reader_test.go
+++ b/reader_test.go
@@ -231,7 +231,7 @@ func TestReaderLegacy(t *testing.T) {
 				}
 				n, err := io.Copy(&out, zr)
 				if err != nil {
-					t.Fatal(err, n)
+					t.Log(err, n) // Both sample files are followed by undecodable data.
 				}
 
 				if got, want := int(n), len(raw); got != want {

--- a/writer.go
+++ b/writer.go
@@ -176,10 +176,8 @@ func (w *Writer) Close() error {
 	}
 	err := w.frame.CloseW(w.src, w.num)
 	// It is now safe to free the buffer.
-	if w.data != nil {
-		lz4block.Put(w.data)
-		w.data = nil
-	}
+	lz4block.Put(w.data)
+	w.data = nil
 	return err
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -33,7 +33,6 @@ func TestWriter(t *testing.T) {
 		for _, option := range []lz4.Option{
 			lz4.ConcurrencyOption(1),
 			lz4.BlockChecksumOption(true),
-			lz4.SizeOption(123),
 			lz4.ConcurrencyOption(4),
 		} {
 			label := fmt.Sprintf("%s/%s", fname, option)
@@ -78,12 +77,6 @@ func TestWriter(t *testing.T) {
 
 				if got, want := out.Bytes(), raw; !bytes.Equal(got, want) {
 					t.Fatal("uncompressed data does not match original")
-				}
-
-				if strings.Contains(option.String(), "SizeOption") {
-					if got, want := zr.Size(), 123; got != want {
-						t.Errorf("invalid sizes: got %d; want %d", got, want)
-					}
 				}
 			})
 		}


### PR DESCRIPTION
This fixes various test breakages introduced in #202, #220, #228 and #229.

Unfortunately it deletes some test code to do so, because those tests are incompatible with #229, in particular.