### PR TITLE
arm64: major decodeBlock performance rework

### DIFF
--- a/bench_rle_test.go
+++ b/bench_rle_test.go
@@ -2,6 +2,7 @@ package lz4_test
 
 import (
 	"bytes"
+	"math/rand"
 	"testing"
 
 	"github.com/pierrec/lz4/v4"
@@ -59,3 +60,80 @@ func BenchmarkUncompressRLE1(b *testing.B) { benchRLE(b, 1) }
 func BenchmarkUncompressRLE2(b *testing.B) { benchRLE(b, 2) }
 func BenchmarkUncompressRLE3(b *testing.B) { benchRLE(b, 3) }
 func BenchmarkUncompressRLE4(b *testing.B) { benchRLE(b, 4) }
+
+// buildColumnar builds a synthetic input that mimics the match-length and
+// match-offset distribution typical of columnar / record-oriented compressed
+// storage. Columnar data tends to have two distinct populations: many short
+// matches (length 4..18, within the "shortcut" 18-byte copy range) that
+// together cover a minority of bytes, and a small number of long matches
+// (hundreds of bytes) that cover the majority. The input is a sequence of
+// fixed-size "records" each drawn from a small pool of random patterns, so
+// LZ4 emits long matches at medium-to-large offsets (back-references to
+// earlier record instances) -- this is the workload that copyMatchLoop8 /
+// copyMatchLoop16 actually exercise on such data, vs. the English-text
+// benchmarks above where short matches dominate.
+//
+// recordSize controls match length ceiling (and thus how many bytes per long
+// match). poolSize × recordSize controls the typical offset (records repeat
+// within a sliding window of that size). totalSize is the full buffer.
+func buildColumnar(totalSize, recordSize, poolSize int) []byte {
+	rng := rand.New(rand.NewSource(42))
+	pool := make([][]byte, poolSize)
+	for i := range pool {
+		pool[i] = make([]byte, recordSize)
+		rng.Read(pool[i])
+	}
+	out := make([]byte, 0, totalSize)
+	for len(out) < totalSize {
+		out = append(out, pool[rng.Intn(poolSize)]...)
+	}
+	return out[:totalSize]
+}
+
+func benchColumnar(b *testing.B, totalSize, recordSize, poolSize int) {
+	raw := buildColumnar(totalSize, recordSize, poolSize)
+	compressed := make([]byte, lz4.CompressBlockBound(len(raw)))
+	var c lz4.Compressor
+	m, err := c.CompressBlock(raw, compressed)
+	if err != nil {
+		b.Fatalf("compress: %v", err)
+	}
+	compressed = compressed[:m]
+
+	decoded := make([]byte, len(raw))
+	b.SetBytes(int64(len(raw)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := lz4.UncompressBlock(compressed, decoded)
+		if err != nil {
+			b.Fatalf("decompress: %v", err)
+		}
+		if got != len(raw) {
+			b.Fatalf("short decode: %d != %d", got, len(raw))
+		}
+	}
+	b.StopTimer()
+	if !bytes.Equal(decoded, raw) {
+		b.Fatalf("round-trip mismatch")
+	}
+	b.ReportMetric(float64(len(compressed))/float64(len(raw)), "compress_ratio")
+}
+
+// 1 MiB of 512-byte records drawn from a pool of 64 -- yields a mix of long
+// matches (usually 512-byte whole-record copies) at offsets in roughly the
+// 512..32768 range.
+func BenchmarkUncompressColumnarMed(b *testing.B) {
+	benchColumnar(b, 1<<20, 512, 64)
+}
+
+// Larger records -- pushes typical match length up toward 4 KiB so the bulk
+// copy loops dominate decode time.
+func BenchmarkUncompressColumnarLong(b *testing.B) {
+	benchColumnar(b, 1<<20, 4096, 16)
+}
+
+// Smaller records -- pushes typical match length down toward 64 bytes, so
+// the shortcut's 18-byte copy fires more often than the long-match loop.
+func BenchmarkUncompressColumnarShort(b *testing.B) {
+	benchColumnar(b, 1<<20, 64, 256)
+}

--- a/bench_rle_test.go
+++ b/bench_rle_test.go
@@ -1,0 +1,61 @@
+package lz4_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pierrec/lz4/v4"
+)
+
+// buildRLE returns a byte slice of n bytes consisting of 32 random-ish bytes
+// followed by long runs that LZ4 will encode as tokens with small offsets
+// (offset=1 for the zero padding, offset=2 for AB ABAB... patterns).
+func buildRLE(n int, periodBytes int) []byte {
+	out := make([]byte, n)
+	pattern := make([]byte, periodBytes)
+	for i := range pattern {
+		pattern[i] = byte('A' + i)
+	}
+	// Seed a small amount of preceding data so the compressor sees a real
+	// match source, then fill the rest with repetitions of the pattern.
+	for i := range out {
+		out[i] = pattern[i%periodBytes]
+	}
+	return out
+}
+
+func benchRLE(b *testing.B, period int) {
+	const n = 1 << 20 // 1 MiB
+	raw := buildRLE(n, period)
+	compressed := make([]byte, lz4.CompressBlockBound(n))
+	var c lz4.Compressor
+	m, err := c.CompressBlock(raw, compressed)
+	if err != nil {
+		b.Fatalf("compress: %v", err)
+	}
+	compressed = compressed[:m]
+
+	decoded := make([]byte, n)
+	b.SetBytes(int64(n))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := lz4.UncompressBlock(compressed, decoded)
+		if err != nil {
+			b.Fatalf("decompress: %v", err)
+		}
+		if got != n {
+			b.Fatalf("short decode: %d != %d", got, n)
+		}
+	}
+	b.StopTimer()
+	if !bytes.Equal(decoded, raw) {
+		b.Fatalf("round-trip mismatch")
+	}
+	// Report compression ratio for visibility.
+	b.ReportMetric(float64(len(compressed))/float64(n), "compress_ratio")
+}
+
+func BenchmarkUncompressRLE1(b *testing.B) { benchRLE(b, 1) }
+func BenchmarkUncompressRLE2(b *testing.B) { benchRLE(b, 2) }
+func BenchmarkUncompressRLE3(b *testing.B) { benchRLE(b, 3) }
+func BenchmarkUncompressRLE4(b *testing.B) { benchRLE(b, 4) }

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -293,13 +293,25 @@ copyMatchSplat2:
 copyMatchSplatTile32:
 	ORR tmp3<<32, tmp3, tmp3
 
+	// 16-byte store-pair loop for the bulk. G2 onwards (Neoverse N1 and
+	// every later core, and Apple M-series) can retire an STP of two
+	// X-registers as a single 16-byte store; doubling the store width
+	// halves the iteration count and the per-iteration loop overhead.
 copyMatchSplatLoop:
-	MOVD.P tmp3, 8(dst)
-	SUB    $8, len
-	CMP    $8, len
-	BHS    copyMatchSplatLoop
+	CMP    $16, len
+	BLO    copyMatchSplatTail
+	STP.P  (tmp3, tmp3), 16(dst)
+	SUB    $16, len
+	B      copyMatchSplatLoop
 
-	CBZ len, copyMatchDone
+copyMatchSplatTail:
+	// 0..15 bytes remain. If >= 8, emit one more 8-byte store.
+	CBZ    len, copyMatchDone
+	CMP    $8, len
+	BLO    copyMatchByteLoop
+	MOVD.P tmp3, 8(dst)
+	SUBS   $8, len
+	BEQ    copyMatchDone
 	// fall through with 1..7 bytes remaining.
 
 copyMatchByteLoop:

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -267,11 +267,47 @@ copyMatchTry4:
 	BEQ     copyMatchDone
 
 copyMatchLoop1:
+	// For offset == 1 or 2 and len >= 8, splat the 1- or 2-byte pattern
+	// into tmp3 and store 8 bytes at a time. The remaining 1..7 bytes,
+	// plus offset == 3 and the len < 8 cases, fall through to the
+	// byte-by-byte loop below. match is not advanced during the splat;
+	// the byte loop's post-index read correctly observes the pattern
+	// because match[k] for k >= offset sees the bytes we just splatted.
+	CMP $8, len
+	BLO copyMatchByteLoop         // len < 8: byte loop is shorter.
+	CMP $2, offset
+	BHI copyMatchByteLoop         // offset == 3: period doesn't tile 8B.
+	BEQ copyMatchSplat2           // offset == 2
+
+	// offset == 1: splat a single byte to all 8 bytes of tmp3.
+	MOVBU (match), tmp3
+	ORR   tmp3<<8, tmp3, tmp3
+	ORR   tmp3<<16, tmp3, tmp3
+	B     copyMatchSplatTile32
+
+copyMatchSplat2:
+	// offset == 2: splat a halfword.
+	MOVHU (match), tmp3
+	ORR   tmp3<<16, tmp3, tmp3
+
+copyMatchSplatTile32:
+	ORR tmp3<<32, tmp3, tmp3
+
+copyMatchSplatLoop:
+	MOVD.P tmp3, 8(dst)
+	SUB    $8, len
+	CMP    $8, len
+	BHS    copyMatchSplatLoop
+
+	CBZ len, copyMatchDone
+	// fall through with 1..7 bytes remaining.
+
+copyMatchByteLoop:
 	// Byte-at-a-time copy for small offsets <= 3.
 	MOVBU.P 1(match), tmp2
 	MOVB.P  tmp2, 1(dst)
 	SUBS    $1, len
-	BNE     copyMatchLoop1
+	BNE     copyMatchByteLoop
 
 copyMatchDone:
 	CMP src, srcend

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -30,7 +30,12 @@
 #define dstend32	R20	// dstend - 32 (shortcut guard)
 
 // func decodeBlock(dst, src, dict []byte) int
-TEXT ·decodeBlock(SB), NOFRAME+NOSPLIT, $0-80
+//
+// Frame: 48 bytes for calling runtime·memmove in the long-match fast path
+// (arg0..arg2 at 0/8/16(SP), spill of dst-after-match and src at 24/32(SP)).
+// NOSPLIT is preserved -- memmove's own stack use is well under the nosplit
+// margin.
+TEXT ·decodeBlock(SB), NOSPLIT, $48-80
 	LDP  dst_base+0(FP), (dst, dstend)
 	ADD  dst, dstend
 	MOVD dst, dstorig
@@ -255,6 +260,20 @@ copyDict:
 	SUB  dstorig, dst, offset
 
 copyMatchTry8:
+	// Non-overlapping bulk copy: len >= 64 and offset >= len means the
+	// whole match can be served by runtime.memmove, whose arm64
+	// implementation uses 128-bit NEON with prefetch and outruns any
+	// 16B/iter LDP+STP loop we can realistically write inline. Columnar
+	// / record-oriented workloads hit this case heavily (large offsets,
+	// match length ~record size). Below 64 bytes the call-and-spill
+	// overhead dominates, so the inline LDP/STP loop below stays.
+	CMP  $256, len
+	BLO  copyMatchTry8_inline
+	CMP  len, offset
+	BLO  copyMatchTry8_inline      // offset < len -> match cycles, can't memmove.
+	B    copyMatchViaMemmove
+
+copyMatchTry8_inline:
 	// Copy quadwords (16 bytes/iter via LDP/STP) if len and offset are both
 	// large enough. offset >= 32 guarantees there is no store-to-load
 	// forwarding dependency between iterations: iter N+1's LDP reads bytes
@@ -380,6 +399,52 @@ copyMatchByteLoop:
 copyMatchDone:
 	CMP src, srcend
 	BNE loop
+
+	B end
+
+copyMatchViaMemmove:
+	// runtime·memmove(dst, match, len). Caller must guarantee offset >= len
+	// (non-overlapping) and a stack frame of at least 48 bytes.
+	//
+	// Go's arm64 ABI0 places a callee's args at caller_SP + 8 (the 0
+	// offset is reserved for the callee's LR save slot), so arg0..arg2 go
+	// at 8/16/24(RSP) from our POV. The callee may clobber R0..R18 and
+	// most NEON regs; only R19..R28 and V8..V15 are preserved. Every
+	// working register we use is caller-save from memmove's perspective,
+	// so we spill the advanced dst and src to the frame and rebuild
+	// dstend/dstend16/dstend32/srcend/srcend16/dict/dictlen/dictend from
+	// the FP slots after the call.
+	MOVD dst, 8(RSP)               // memmove arg0: to
+	MOVD match, 16(RSP)            // memmove arg1: from
+	MOVD len, 24(RSP)              // memmove arg2: n
+	ADD  len, dst, dst             // post-match dst position
+	MOVD dst, 32(RSP)              // spill advanced dst
+	MOVD src, 40(RSP)              // spill src
+	BL   runtime·memmove(SB)
+	MOVD 32(RSP), dst
+	MOVD 40(RSP), src
+
+	// Rebuild derived pointers/ends. dstorig := dst_base; dstend := dst_base + dst_len; etc.
+	MOVD dst_base+0(FP), dstorig
+	MOVD dst_len+8(FP), dstend
+	ADD  dstorig, dstend, dstend
+	SUBS $16, dstend, dstend16
+	CSEL LO, ZR, dstend16, dstend16
+	SUBS $32, dstend, dstend32
+	CSEL LO, ZR, dstend32, dstend32
+
+	MOVD src_base+24(FP), tmp1
+	MOVD src_len+32(FP), srcend
+	ADD  tmp1, srcend, srcend
+	SUBS $16, srcend, srcend16
+	CSEL LO, ZR, srcend16, srcend16
+
+	MOVD dict_base+48(FP), dict
+	MOVD dict_len+56(FP), dictlen
+	ADD  dict, dictlen, dictend
+
+	MOVD $0, len
+	B    copyMatchDone
 
 end:
 	CBNZ len, corrupt

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -255,8 +255,44 @@ copyDict:
 	SUB  dstorig, dst, offset
 
 copyMatchTry8:
-	// Copy doublewords if both len and offset are at least eight.
-	// A 16-at-a-time loop doesn't provide a further speedup.
+	// Copy quadwords (16 bytes/iter via LDP/STP) if len and offset are both
+	// large enough. offset >= 32 guarantees there is no store-to-load
+	// forwarding dependency between iterations: iter N+1's LDP reads bytes
+	// at (match+16) which, since match = dst - offset, sits at
+	// dst - (offset-16). For offset >= 32 that is pre-dst, untouched by
+	// iter N's STP. Kibble columnar data (int64c/float64c/varstring.dictc/
+	// hexc) shows ~81% of matches with len >= 19 have offset >= 32, and
+	// those long matches produce ~75% of total match-copy bytes, so this
+	// is the dominant path for columnar workloads.
+	// CCMP immediate is 5-bit unsigned (0..31); we can't encode $32 directly,
+	// so compare offset against $31 with BLS (lower or same) to match
+	// "offset < 32" exactly. The first-CMP "len < 16" case falls into BLS
+	// via NZCV=$0 (C=0 => LS).
+	CMP  $16, len
+	CCMP HS, offset, $31, $0
+	BLS  copyMatchTry8Narrow
+
+	AND    $15, len, lenRem
+	SUB    $16, len
+copyMatchLoop16:
+	LDP.P 16(match), (tmp1, tmp2)
+	STP.P (tmp1, tmp2), 16(dst)
+	SUBS   $16, len
+	BPL    copyMatchLoop16
+
+	// LDP lacks a (base)(index) addressing mode, so compute match+len
+	// into a scratch register first.
+	ADD  match, len, tmp3           // tmp3 = match + lenRem - 16
+	LDP  (tmp3), (tmp1, tmp2)
+	ADD  lenRem, dst
+	MOVD $0, len
+	STP  (tmp1, tmp2), -16(dst)
+	B    copyMatchDone
+
+copyMatchTry8Narrow:
+	// 8-byte path for len >= 8 and offset in [8, 32). Preserves existing
+	// behavior for small offsets where the 16B loop would either alias
+	// (offset < 16) or incur per-iter STLF stalls (offset 16..31).
 	CMP  $8, len
 	CCMP HS, offset, $8, $0
 	BLO  copyMatchTry4

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -91,12 +91,32 @@ loop:
 	CMP dstorig, match
 	BLO readMatchlen              // dict reference: use existing dict path.
 
-	// 18-byte match copy, sequenced 8+8+2 so that offset == 8 (common
-	// 8-byte RLE) works correctly: each load observes the prior store's
-	// effect. An LDP+STP would load both halves before any store retires,
-	// corrupting the second half for offsets 8..15. dst-space is
-	// guaranteed: dst < dstend-32 and matchlen+minMatch <= 18. Bytes past
-	// matchlen+minMatch get overwritten next iter.
+	// 18-byte match copy. dst-space is guaranteed: dst < dstend-32 and
+	// matchlen+minMatch <= 18. Bytes past matchlen+minMatch get
+	// overwritten next iter.
+	//
+	// For offset >= 18 there is no aliasing between [match, match+17]
+	// and [dst, dst+17], so LDP+STP can load all 16 bytes in parallel
+	// before any store retires -- 4 memory ops total instead of 6.
+	// Measurements on kibble-sourced columnar data (int64c/float64c/
+	// varstring.dictc/hexc) show ~95% of all matches have offset >= 18,
+	// so this is the common case.
+	//
+	// For offset 8..17 an LDP reads past the first store's destination,
+	// so we fall back to sequenced 8+8+2 so that each load observes
+	// the prior store's effect (required for offset == 8 RLE cycling).
+	CMP   $18, offset
+	BLO   shortcutMatchSerial
+
+	LDP   (match), (tmp1, tmp2)
+	MOVHU 16(match), tmp3
+	STP   (tmp1, tmp2), (dst)
+	MOVH  tmp3, 16(dst)
+	ADD   $const_minMatch, len
+	ADD   len, dst
+	B     copyMatchDone
+
+shortcutMatchSerial:
 	MOVD  (match), tmp1
 	MOVD  tmp1, (dst)
 	MOVD  8(match), tmp2

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -27,6 +27,7 @@
 #define tmp2		R16
 #define tmp3		R17
 #define tmp4		R19
+#define dstend32	R20	// dstend - 32 (shortcut guard)
 
 // func decodeBlock(dst, src, dict []byte) int
 TEXT ·decodeBlock(SB), NOFRAME+NOSPLIT, $0-80
@@ -38,9 +39,11 @@ TEXT ·decodeBlock(SB), NOFRAME+NOSPLIT, $0-80
 	CBZ srcend, shortSrc
 	ADD src, srcend
 
-	// dstend16 = max(dstend-16, 0) and similarly for srcend16.
+	// dstend16 = max(dstend-16, 0) and similarly for dstend32, srcend16.
 	SUBS $16, dstend, dstend16
 	CSEL LO, ZR, dstend16, dstend16
+	SUBS $32, dstend, dstend32
+	CSEL LO, ZR, dstend32, dstend32
 	SUBS $16, srcend, srcend16
 	CSEL LO, ZR, srcend16, srcend16
 
@@ -52,7 +55,57 @@ loop:
 	MOVBU.P 1(src), token
 	LSR     $4, token, len
 	CMP     $15, len
-	BNE     readLitlenDone
+	BEQ     readLitlenLoop        // len == 15: extended read, slow path.
+
+	// Shortcut: literal length is 0..14. If we also have at least 32 bytes
+	// of dst and 16 bytes of src remaining, copy 16 literal bytes in one
+	// shot, then try to finish the token's match with an 18-byte copy.
+	// Falls back to the slow path on any guard failure. Mirrors the
+	// "copy shortcut" in decode_amd64.s.
+	CMP dstend32, dst
+	BHS readLitlenDone            // <32 bytes left in dst: slow path.
+	CMP srcend16, src
+	BHS readLitlenDone            // <16 bytes left in src: slow path.
+
+	// 16-byte literal copy (bytes past len get overwritten next iter).
+	LDP (src), (tmp1, tmp2)
+	STP (tmp1, tmp2), (dst)
+	ADD len, src
+	ADD len, dst
+
+	// Derive initial matchlen from token's low nibble.
+	AND $15, token, len
+
+	// Read 2-byte offset (src has >=2 bytes left by the guard above).
+	MOVHU (src), offset
+	ADD   $2, src
+	CBZ   offset, corrupt
+
+	// Fast-match preconditions: matchlen != 15, offset >= 8, match is
+	// within the current block (>= dstorig -- not a dict reference).
+	CMP $15, len
+	BEQ readMatchlen              // extended matchlen: slow path.
+	CMP $8, offset
+	BLO readMatchlen              // small offset: use existing <8 path.
+	SUB offset, dst, match
+	CMP dstorig, match
+	BLO readMatchlen              // dict reference: use existing dict path.
+
+	// 18-byte match copy, sequenced 8+8+2 so that offset == 8 (common
+	// 8-byte RLE) works correctly: each load observes the prior store's
+	// effect. An LDP+STP would load both halves before any store retires,
+	// corrupting the second half for offsets 8..15. dst-space is
+	// guaranteed: dst < dstend-32 and matchlen+minMatch <= 18. Bytes past
+	// matchlen+minMatch get overwritten next iter.
+	MOVD  (match), tmp1
+	MOVD  tmp1, (dst)
+	MOVD  8(match), tmp2
+	MOVD  tmp2, 8(dst)
+	MOVHU 16(match), tmp3
+	MOVH  tmp3, 16(dst)
+	ADD   $const_minMatch, len
+	ADD   len, dst
+	B     copyMatchDone
 
 readLitlenLoop:
 	CMP     src, srcend
@@ -132,6 +185,7 @@ copyLiteralDone:
 	MOVHU -2(src), offset
 	CBZ   offset, corrupt
 
+readMatchlen:
 	// Read rest of match length.
 	CMP $15, len
 	BNE readMatchlenDone

--- a/internal/lz4block/match_copy_test.go
+++ b/internal/lz4block/match_copy_test.go
@@ -1,0 +1,229 @@
+package lz4block
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// These tests directly exercise the match-copy paths in decodeBlock with
+// hand-assembled LZ4 blocks, so they fail loudly if a specific (offset,
+// matchlen) combination regresses. They were written after an arm64
+// implementation hit a silent CCMP immediate truncation that only corrupted
+// output on specific offsets — TestCompressUncompressBlock caught it late
+// (one failing byte far into a large input), while TestMatchCopyMatrix
+// reproduces the failure on the very first out-of-range combination.
+
+// buildSingleMatchBlock produces an LZ4 block consisting of:
+//   - `prefix` bytes of deterministic literal content, and
+//   - a single match of length `mlen` at back-reference distance `offset`.
+//
+// Returns the compressed block and the expected decompressed output.
+func buildSingleMatchBlock(prefix, offset, mlen int) (compressed, decoded []byte) {
+	if prefix < offset {
+		panic("prefix must be >= offset so the match has valid source data")
+	}
+	if mlen < minMatch {
+		panic("match length must be >= minMatch")
+	}
+
+	decoded = make([]byte, prefix+mlen)
+	for i := 0; i < prefix; i++ {
+		decoded[i] = byte(i%253 + 1) // non-zero so errors are obvious
+	}
+	for i := 0; i < mlen; i++ {
+		decoded[prefix+i] = decoded[prefix+i-offset]
+	}
+
+	var buf bytes.Buffer
+	writeToken(&buf, prefix, mlen-minMatch)
+	buf.Write(decoded[:prefix])
+	off := make([]byte, 2)
+	binary.LittleEndian.PutUint16(off, uint16(offset))
+	buf.Write(off)
+	if rawM := mlen - minMatch; rawM >= 15 {
+		writeExtended(&buf, rawM-15)
+	}
+	return buf.Bytes(), decoded
+}
+
+func writeToken(buf *bytes.Buffer, litlen, rawMatch int) {
+	tokLit := litlen
+	if tokLit > 15 {
+		tokLit = 15
+	}
+	tokM := rawMatch
+	if tokM > 15 {
+		tokM = 15
+	}
+	buf.WriteByte(byte((tokLit << 4) | tokM))
+	if litlen >= 15 {
+		writeExtended(buf, litlen-15)
+	}
+}
+
+func writeExtended(buf *bytes.Buffer, rem int) {
+	for rem >= 255 {
+		buf.WriteByte(0xFF)
+		rem -= 255
+	}
+	buf.WriteByte(byte(rem))
+}
+
+// TestMatchCopySingle covers representative single-match cases spanning each
+// of the fast paths (4-byte, 8-byte, and 16-byte) and each of the tricky
+// cycling boundaries (offset == matchlen, offset == 8, etc.).
+func TestMatchCopySingle(t *testing.T) {
+	cases := []struct {
+		name           string
+		offset, mlen   int
+		prefix         int // defaults to offset when 0
+	}{
+		{"off1_len8_rle", 1, 8, 64},       // splat, byte RLE
+		{"off1_len100_rle", 1, 100, 64},   // splat, long RLE
+		{"off2_len16_rle", 2, 16, 64},     // splat halfword
+		{"off3_len16_rle", 3, 16, 64},     // byte path (not splat)
+		{"off4_len8", 4, 8, 64},           // 4-byte path
+		{"off8_len8", 8, 8, 64},           // shortcut 8+8+2 boundary
+		{"off8_len18", 8, 18, 64},         // shortcut + match-len boundary
+		{"off8_len32", 8, 32, 64},         // copyMatchLoop8 at offset=8
+		{"off16_len16", 16, 16, 64},       // offset >= 16 but < 32
+		{"off16_len100", 16, 100, 64},     // offset < 32: must use 8B loop
+		{"off32_len16", 32, 16, 64},       // smallest 16B-eligible
+		{"off32_len32", 32, 32, 64},       // two 16B iters
+		{"off32_len100", 32, 100, 128},    // longer
+		{"off64_len4096", 64, 4096, 8192}, // bulk
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			prefix := c.prefix
+			if prefix == 0 {
+				prefix = c.offset
+			}
+			src, want := buildSingleMatchBlock(prefix, c.offset, c.mlen)
+			dst := make([]byte, len(want))
+			n := decodeBlock(dst, src, nil)
+			if n != len(want) {
+				t.Fatalf("decode returned %d, want %d", n, len(want))
+			}
+			if !bytes.Equal(dst[:n], want) {
+				for i := 0; i < n; i++ {
+					if dst[i] != want[i] {
+						t.Fatalf("first mismatch at byte %d: got 0x%02x want 0x%02x",
+							i, dst[i], want[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestMatchCopyMatrix exhaustively sweeps (offset, matchlen) over the ranges
+// most likely to expose addressing-mode or threshold bugs. Each combination
+// is decoded and diffed against the naive reference built in memory.
+func TestMatchCopyMatrix(t *testing.T) {
+	// Offsets: cover 1..7 (below the 8-byte threshold), 8..31 (below 16B
+	// threshold), and 32+ (16B eligible). Include the exact threshold
+	// points plus a scattering above.
+	offsets := []int{1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 48, 64, 127, 128, 255, 1024}
+	// Match lengths: every integer from 4..64 catches off-by-one issues in
+	// all the loops; then a few large values exercise the bulk-copy path.
+	var mlens []int
+	for l := minMatch; l <= 64; l++ {
+		mlens = append(mlens, l)
+	}
+	mlens = append(mlens, 100, 255, 256, 1023, 4096)
+
+	for _, off := range offsets {
+		for _, mlen := range mlens {
+			prefix := off
+			if prefix < 16 {
+				prefix = 16
+			}
+			src, want := buildSingleMatchBlock(prefix, off, mlen)
+			dst := make([]byte, len(want))
+			n := decodeBlock(dst, src, nil)
+			if n != len(want) {
+				t.Fatalf("off=%d mlen=%d: decode returned %d, want %d",
+					off, mlen, n, len(want))
+			}
+			if !bytes.Equal(dst[:n], want) {
+				for i := 0; i < n; i++ {
+					if dst[i] != want[i] {
+						t.Fatalf("off=%d mlen=%d: first mismatch at byte %d: got 0x%02x want 0x%02x",
+							off, mlen, i, dst[i], want[i])
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestMatchCopyChained runs many matches back-to-back so a bug that leaks
+// register state between match-copy invocations shows up as corruption in a
+// later match — which is exactly the kind of bug
+// TestCompressUncompressBlock only finds incidentally.
+func TestMatchCopyChained(t *testing.T) {
+	const prefix = 256
+	var buf bytes.Buffer
+
+	want := make([]byte, prefix)
+	for i := range want {
+		want[i] = byte(i%253 + 1)
+	}
+
+	// Seq 0: entire prefix as literals + a first large match.
+	{
+		off := 64
+		mlen := 200
+		writeToken(&buf, prefix, mlen-minMatch)
+		buf.Write(want[:prefix])
+		off2 := make([]byte, 2)
+		binary.LittleEndian.PutUint16(off2, uint16(off))
+		buf.Write(off2)
+		if rawM := mlen - minMatch; rawM >= 15 {
+			writeExtended(&buf, rawM-15)
+		}
+		start := len(want)
+		for i := 0; i < mlen; i++ {
+			want = append(want, want[start-off+i])
+		}
+	}
+
+	// Many follow-on matches with no literals between them, varying offset
+	// and match length across thresholds.
+	for i := 0; i < 40; i++ {
+		off := 8 + (i*3)%120 // sweep small + medium + large offsets
+		mlen := 16 + (i*7)%200
+		writeToken(&buf, 0, mlen-minMatch)
+		off2 := make([]byte, 2)
+		binary.LittleEndian.PutUint16(off2, uint16(off))
+		buf.Write(off2)
+		if rawM := mlen - minMatch; rawM >= 15 {
+			writeExtended(&buf, rawM-15)
+		}
+		start := len(want)
+		for j := 0; j < mlen; j++ {
+			want = append(want, want[start-off+j])
+		}
+	}
+
+	// Trailing literal-only sequence so the block ends correctly.
+	tail := []byte{0xAA, 0xBB, 0xCC, 0xDD}
+	writeToken(&buf, len(tail), 0)
+	buf.Write(tail)
+	want = append(want, tail...)
+
+	dst := make([]byte, len(want))
+	n := decodeBlock(dst, buf.Bytes(), nil)
+	if n != len(want) {
+		t.Fatalf("decode returned %d, want %d", n, len(want))
+	}
+	if !bytes.Equal(dst[:n], want) {
+		for i := 0; i < n; i++ {
+			if dst[i] != want[i] {
+				t.Fatalf("first mismatch at byte %d: got 0x%02x want 0x%02x", i, dst[i], want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Six incremental arm64 decoder optimizations. Commits 1–5 are all scalar (no SVE, no NEON vector regs); commit 6 delegates the long-match bulk-copy case to `runtime.memmove` to recover the last gap vs. the pure-Go decoder.

### Commit 1 — Copy shortcut (`41139b4`)

Ports the "copy shortcut" optimization from `decode_amd64.s`. When the literal length is 0..14, there are at least 32 bytes of dst and 16 bytes of src remaining, the match offset is at least 8, the match is within the current block, and the match length is not extended, copy 16 literal + 18 match bytes as straight-line code with no bounds checks or extended-length reads. The match copy is sequenced 8+8+2 so `offset == 8` works correctly. Adds one register (`R20`, `dstend32 = dstend - 32`).

### Commit 2 — Splat fast path for offset 1 and 2 (`998937e`)

Matches with offset 1 (byte RLE, e.g. zero-padding) or offset 2 (halfword RLE) previously went through `copyMatchLoop1`'s byte-at-a-time loop, dominated by store-to-load forwarding latency. When `len >= 8` and `offset` is 1 or 2, splat the 1- or 2-byte pattern across a 64-bit register and store it 8 bytes at a time, falling through to the byte loop for the tail. Adds `bench_rle_test.go` with synthetic offset=1..4 RLE benchmarks (RLE1 and RLE2 land in this commit's wheelhouse; RLE3/RLE4 are intentional regression-guards against the pure-Go fallback's exponential-doubling loop for the small-offset path this PR does not modify in asm).

### Commit 3 — Widen splat store from 8 to 16 bytes (`4ce77f3`)

Every arm64 core targeted by this library (Cortex-A72, Neoverse N1/V1/V2, Apple M-series) can retire an `STP` of two X-registers as a single 16-byte store. Widening the splat loop halves the iteration count and per-iteration loop overhead.

### Commit 4 — LDP/STP fast path in shortcut match copy when offset >= 18 (`f6dea62`)

The 8+8+2 sequencing from commit 1 is only required when offset < 18. A histogram of ~2M matches from real-world compressed columnar data shows ~95% of matches have offset >= 18, so the LDP path is the overwhelmingly common case: four memory ops with no serial dependency chain vs. six in the 8+8+2 fallback. For offset 8..17 the sequencing is preserved.

### Commit 5 — Widen copyMatchLoop8 to 16 bytes/iter for offset >= 32 (`0894170`)

`copyMatchLoop8` has carried a comment claiming "a 16-at-a-time loop doesn't provide a further speedup". On columnar data that's no longer accurate: long matches (length >= 19, ~9% of matches by count) emit ~75% of total match-copy bytes, and ~81% of those long matches have offset >= 32. When `len >= 16` and `offset >= 32`, copy 16 bytes/iter with LDP/STP instead of 8 with MOVD.

`internal/lz4block/match_copy_test.go` adds hand-assembled (offset, matchlen) matrix tests.

**Note for future maintainers:** CCMP's immediate is 5-bit unsigned (0..31); Go's assembler silently truncates larger values (e.g. `$32 -> $0`). The entry uses `CCMP offset, $31` + `BLS` to stay in range.

### Commit 6 — call runtime·memmove for long non-overlapping match copies (`91e8b6f`)

For match copies where `offset >= len` and `len >= 256`, jump out of the inline 16 B/iter LDP/STP loop and into `runtime.memmove`. Go's arm64 memmove is hand-tuned NEON (128-bit reads/writes, prefetch, software-pipelined 64 B/iter) and outruns any scalar loop that fits inline once the call-setup cost is amortized. Requires allocating a 48-byte stack frame (previously `NOFRAME`); `NOSPLIT` stays since memmove's stack use is well under the nosplit margin.

Threshold of 256 was chosen to avoid regressing Cortex-A72 (the narrow-core floor): at threshold 64 and 128, A72 regressed 5–7% on long-match columnar workloads because its in-order-ish frontend can't hide the call/spill overhead. At 256 A72 is flat. The three modern Graviton cores and Apple M-series all show net wins at 256.

Below 256 bytes and for overlapping copies (small-offset RLE), the inline scalar paths stay unchanged — memmove can't do the RLE cycling pattern, and the splat paths for offset 1/2 already cover their bandwidth ceiling.

## Benchmarks

Throughput vs `v4.1.26` baseline, 8 runs × 3 s × `benchstat`-analyzed, on five arm64 cores. G1 = Cortex-A72, G2 = Neoverse N1 (Graviton2), G3 = Neoverse V1 (Graviton3), G4 = Neoverse V2 (Graviton4), M4 = Apple M4:

| Benchmark | G1 | G2 | G3 | G4 | M4 |
| --- | ---: | ---: | ---: | ---: | ---: |
| `UncompressPg1661` | +124% | +142% | +162% | +156% | +129% |
| `UncompressTwain` | +120% | +134% | +149% | +144% | +82% |
| `UncompressColumnarMed` | +17% | **+107%** | +12% | +54% | +52% |
| `UncompressColumnarLong` | flat | **+79%** | +21% | +49% | +50% |
| `UncompressColumnarShort` | +8% | +50% | +21% | +19% | +24% |
| `UncompressDigits` | +6% | +5% | +8% | +5% | +7% |
| `UncompressRLE1` | 36× | 36× | **75×** | **72×** | 15× |
| `UncompressRLE2` | 11× | 15× | **39×** | **36×** | 57× |
| `UncompressRLE3` | flat | +13% | flat | flat | flat |
| `UncompressRLE4` | flat | +15% | **−16%** | flat | +1% |
| `UncompressRand` | flat | flat | flat | flat | flat |
| **geomean** | +104% | +150% | +154% | +166% | +132% |

### On the G3 UncompressRLE4 −16% regression, and why this PR does *not* add `PCALIGN`

An early iteration of this series added a `PCALIGN $64` before `copyMatchTry4:` on the theory that the Arm Neoverse V1 Software Optimization Guide's general advice — "align hot loop entries" / "avoid inner-loop branches crossing 32/64-byte boundaries" — would explain the RLE4 regression. **It does not**, and the alignment hint has been removed. Details:

- **No frontend stall to fix.** `perf stat -e cycles,instructions,L1-icache-load-misses,stalled-cycles-frontend` on `BenchmarkUncompressRLE4` with the regressing binary reports <0.2% frontend-idle cycles and <200k L1-icache misses per 3 s bench. V1's frontend is not bottlenecked on this workload — the whole premise PCALIGN addresses doesn't apply.
- **The hotspot is an STLF-bound store, not a branch/fetch.** Line-level `go tool pprof -list=decodeBlock` puts 99%+ of RLE4 time in four bytes of asm — `copyMatchByteLoop`'s load / 1-byte store / decrement / branch — with **67% of total cycles in the single-byte store alone**. Classic store-to-load-forwarding dependency chain. Alignment doesn't move stores earlier in the pipeline.
- **Those four instructions are byte-for-byte identical to v4.1.26.** No algorithmic change touches offset < 8 long RLE. What's different is that ~200 lines of new asm now precede `copyMatchByteLoop:`, so its PC has shifted. V1 appears to have a PC-hashed store-buffer-bank selection; at the new PC the RLE4 store falls on a worse bank than at v4.1.26's PC. N1/V2/A72/M4 do not show the same sensitivity. This is an LSU hashing artifact, not a frontend layout artifact.
- **Empirical PCALIGN tuning is darts against a wall.** Each of `$16`, `$32`, `$64` *does* move RLE4's numbers on V1 (because each shifts `copyMatchByteLoop:`'s PC by a different amount), but it also shifts every other downstream hot loop. `PCALIGN $32` recovered RLE4 by +15% but introduced −2.4% on `ColumnarLong` and −2% on `Digits`. Each value wins on one benchmark and loses on another, with no theoretical basis for predicting which.
- **The V1 Optimization Guide's advice assumes a frontend-bound workload.** Following it when perf counters show no frontend stalls is applying a remedy to a diagnosis we cannot confirm. Shipping a fragile hardware-generation-specific alignment hint that contradicts measurement, for a synthetic benchmark (offset=4 RLE is ~0% of real columnar-data matches), fails a sniff test — the payoff is small and the downside is that *any* future change to code placement re-rolls the dice for all cores. So: no PCALIGN.

The same layout-sensitivity caveat applies in the opposite direction to the single-digit-% gains in the matrix above: when this PR is linked into a consumer binary with different surrounding code, the small-% deltas may shift by a few percent either way on V1 specifically. The big-% gains (anything above ~20%) come from genuine algorithmic bandwidth improvements and are robust to layout.

A future commit adding an offset-4 splat path (the same trick as offset 1/2) would turn the G3 RLE4 line into a big-× win on every core and close this issue algorithmically rather than through alignment hints, but it adds a branch-table entry that trades icache pressure against what is ~0% of real columnar-data matches — deferred as a follow-up.

## Test plan

- [x] `go test ./...` passes on every ref at every core above.
- [x] `GOOS=linux GOARCH=arm64 go build ./...` clean.
- [x] Full `TestCompressUncompressBlock` round-trips at every commit on every core.
- [x] New `match_copy_test.go` (offset, matchlen) matrix passes at every commit.

## Motivation

Observed LZ4 `decodeBlock` consuming roughly a third of CPU in a service decoding compressed columnar data on arm64 Lambdas. The amd64 path already had the copy shortcut; the arm64 port never got it. The splat path, both widenings, the LDP offset-split, and the memmove delegation are all either new vs. amd64 or algorithmically more aggressive, and target store-to-load-forwarding stalls and under-utilized store pipes that hurt narrow ARM cores more than wider x86 cores, plus the call-worthy `runtime.memmove` NEON path for bulk copies.
