### PR TITLE
ci: refresh Go matrix to 1.24-1.26 and bump actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ["1.19", "1.20", "1.21"]
+        go: ["1.24", "1.25", "1.26"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - name: test


### PR DESCRIPTION
## Summary

The CI matrix tests Go 1.19/1.20/1.21 with \`actions/checkout@v2\` and \`actions/setup-go@v2\`. All three Go versions are end-of-life (1.21 went EOL in Feb 2024 with the 1.23 release), and the v2 actions depend on Node 16, whose runtime was disabled across all GitHub Actions during 2024 — so the workflow as written no longer starts, independent of what the jobs do.

This PR:

- Updates the Go matrix to 1.24 / 1.25 / 1.26. 1.25 and 1.26 are the two currently-supported versions per [Go's release policy](https://go.dev/doc/devel/release#policy); keeping 1.24 gives one EOL generation of headroom for downstream consumers that haven't migrated yet. Drops 1.19/1.20/1.21 entirely — there is no realistic user still on a Go released before Aug 2022.
- Bumps \`actions/checkout@v2\` → \`v4\` and \`actions/setup-go@v2\` → \`v5\`, both of which use the current Node 20 runner.

No source changes. This is a CI-only refresh.

## Test plan

- [x] YAML lints clean
- [ ] CI green on merge (verifies the matrix + action versions actually run)