### PR TITLE
arm64: fast match copy for offsets 3-7

### DIFF
--- a/bench_rle_test.go
+++ b/bench_rle_test.go
@@ -58,6 +58,9 @@ func benchRLE(b *testing.B, period int) {
 
 func BenchmarkUncompressRLE1(b *testing.B) { benchRLE(b, 1) }
 func BenchmarkUncompressRLE2(b *testing.B) { benchRLE(b, 2) }
+func BenchmarkUncompressRLE5(b *testing.B) { benchRLE(b, 5) }
+func BenchmarkUncompressRLE6(b *testing.B) { benchRLE(b, 6) }
+func BenchmarkUncompressRLE7(b *testing.B) { benchRLE(b, 7) }
 func BenchmarkUncompressRLE3(b *testing.B) { benchRLE(b, 3) }
 func BenchmarkUncompressRLE4(b *testing.B) { benchRLE(b, 4) }
 

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -342,16 +342,15 @@ copyMatchTry4:
 	BEQ     copyMatchDone
 
 copyMatchLoop1:
-	// For offset == 1 or 2 and len >= 8, splat the 1- or 2-byte pattern
-	// into tmp3 and store 8 bytes at a time. The remaining 1..7 bytes,
-	// plus offset == 3 and the len < 8 cases, fall through to the
-	// byte-by-byte loop below. match is not advanced during the splat;
-	// the byte loop's post-index read correctly observes the pattern
-	// because match[k] for k >= offset sees the bytes we just splatted.
+	// For offset <= 2 and len >= 8, splat the 1- or 2-byte pattern
+	// and store 8-16 bytes at a time. Offsets 3..7 with enough length
+	// go to their own splat/tile paths (reachable only with offset < 8:
+	// len >= 8 at this point implies the offset >= 8 cases went through
+	// copyMatchTry8Narrow). Everything else falls to the byte loop.
 	CMP $8, len
 	BLO copyMatchByteLoop         // len < 8: byte loop is shorter.
 	CMP $2, offset
-	BHI copyMatchByteLoop         // offset == 3: period doesn't tile 8B.
+	BHI copyMatchMidPeriod        // offsets 3..7.
 	BEQ copyMatchSplat2           // offset == 2
 
 	// offset == 1: splat a single byte to all 8 bytes of tmp3.
@@ -359,6 +358,60 @@ copyMatchLoop1:
 	ORR   tmp3<<8, tmp3, tmp3
 	ORR   tmp3<<16, tmp3, tmp3
 	B     copyMatchSplatTile32
+
+copyMatchMidPeriod:
+	// offsets 3..7 with len >= 8.
+	CMP  $4, offset
+	BEQ  copyMatchSplat4
+	CMP  $16, len
+	BHS  copyMatchTile
+	B    copyMatchByteLoop
+
+copyMatchSplat4:
+	// offset == 4: splat a word to all 8 bytes of tmp3, then reuse the
+	// 16-byte splat store loop below.
+	MOVWU (match), tmp3
+	B     copyMatchSplatTile32
+
+copyMatchTile:
+	// offsets 3, 5, 6, 7 with len >= 16. The output is periodic with
+	// period == offset. Prefill step = (16/offset)*offset bytes (12..15,
+	// the largest multiple of offset <= 16) byte-by-byte, which makes
+	// [match0, dst) hold >= 16 pattern bytes and leaves dst phase-aligned
+	// to the pattern start. Then load one 16-byte tile from match0 and
+	// store it repeatedly, advancing dst by step so the phase is
+	// preserved. The loop has no loads, so unlike an overlapped-copy
+	// loop it incurs no store-to-load-forwarding stalls.
+	MOVD $16, tmp1
+	UDIV offset, tmp1, tmp2
+	MUL  offset, tmp2, tmp4        // tmp4 = step
+	MOVD match, lenRem             // lenRem = match0, the tile source.
+	MOVD tmp4, tmp1                // tmp1 = prefill byte count.
+
+copyMatchTilePrefill:
+	MOVBU.P 1(match), tmp3
+	MOVB.P  tmp3, 1(dst)
+	SUBS    $1, tmp1
+	BNE     copyMatchTilePrefill
+
+	SUB tmp4, len
+	LDP (lenRem), (tmp1, tmp2)     // 16-byte pattern tile.
+
+copyMatchTileLoop:
+	// Store 16 bytes while at least 16 remain, consuming step bytes per
+	// iteration; the 16-step overlap is rewritten by the next store (or
+	// the tail loop) with identical values.
+	CMP $16, len
+	BLO copyMatchTileTail
+	STP (tmp1, tmp2), (dst)
+	ADD tmp4, dst
+	SUB tmp4, len
+	B   copyMatchTileLoop
+
+copyMatchTileTail:
+	CBZ len, copyMatchDone
+	SUB offset, dst, match         // Re-derive match for the byte loop.
+	B   copyMatchByteLoop
 
 copyMatchSplat2:
 	// offset == 2: splat a halfword.

--- a/internal/lz4block/match_copy_test.go
+++ b/internal/lz4block/match_copy_test.go
@@ -75,15 +75,15 @@ func writeExtended(buf *bytes.Buffer, rem int) {
 // cycling boundaries (offset == matchlen, offset == 8, etc.).
 func TestMatchCopySingle(t *testing.T) {
 	cases := []struct {
-		name           string
-		offset, mlen   int
-		prefix         int // defaults to offset when 0
+		name         string
+		offset, mlen int
+		prefix       int // defaults to offset when 0
 	}{
 		{"off1_len8_rle", 1, 8, 64},       // splat, byte RLE
 		{"off1_len100_rle", 1, 100, 64},   // splat, long RLE
 		{"off2_len16_rle", 2, 16, 64},     // splat halfword
-		{"off3_len16_rle", 3, 16, 64},     // byte path (not splat)
-		{"off4_len8", 4, 8, 64},           // 4-byte path
+		{"off3_len16_rle", 3, 16, 64},     // tile path, exactly one prefill
+		{"off4_len8", 4, 8, 64},           // word-splat path
 		{"off8_len8", 8, 8, 64},           // shortcut 8+8+2 boundary
 		{"off8_len18", 8, 18, 64},         // shortcut + match-len boundary
 		{"off8_len32", 8, 32, 64},         // copyMatchLoop8 at offset=8
@@ -125,7 +125,7 @@ func TestMatchCopyMatrix(t *testing.T) {
 	// Offsets: cover 1..7 (below the 8-byte threshold), 8..31 (below 16B
 	// threshold), and 32+ (16B eligible). Include the exact threshold
 	// points plus a scattering above.
-	offsets := []int{1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 48, 64, 127, 128, 255, 1024}
+	offsets := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 32, 33, 48, 64, 127, 128, 255, 1024}
 	// Match lengths: every integer from 4..64 catches off-by-one issues in
 	// all the loops; then a few large values exercise the bulk-copy path.
 	var mlens []int


### PR DESCRIPTION
## What

Adds fast paths in `decode_arm64.s` for matches with offsets 3–7, which previously fell through to the byte-at-a-time copy loop:

- **offset 4**: splat the 4-byte pattern into an X register and reuse the existing 16-byte STP splat loop (same treatment offsets 1 and 2 already get).
- **offsets 3, 5, 6, 7**: prefill `(16/offset)*offset` bytes (12–15, the largest multiple of the offset ≤ 16) byte-by-byte so `dst` is phase-aligned to the pattern, then load one 16-byte pattern tile and store it repeatedly, advancing `dst` by that step. The loop contains no loads, so there are no store-to-load-forwarding stalls.

The dispatch hangs off the existing `offset > 2` branch that previously jumped straight to the byte loop, so every previously-fast path executes a byte-identical instruction sequence (an earlier draft that added compares in front of the short-match path cost ~3% on short-match workloads; this structure avoids that).

## Why

On a Cortex-A72, offsets 3–7 decoded at ~1 GB/s while offsets 1, 2, and ≥ 8 ran at 8–11 GB/s. The reference C decoder has no such cliff — it handles all offsets < 8 with its `inc32table`/`dec64table` path — so streams produced by other encoders could hit a ~10x arm64 decode penalty on this input class. This brings the arm64 decoder to rough parity with the C decoder's worst-case behavior.

## Benchmarks (Cortex-A72, 1 MiB periodic runs)

| benchmark | before | after |
|---|---|---|
| UncompressRLE3 | 1.06 GB/s | 10.7 GB/s |
| UncompressRLE4 | 1.08 GB/s | 10.9 GB/s |
| UncompressRLE5–7 (new) | ~1 GB/s | 8.3–10.7 GB/s |

Honest scoping: this is a worst-case fix, not a typical-case speedup. Histograms of match offsets over a real-file corpus (text, ELF binaries, raw RGB/RGBA pixels, PCM audio, JSON logs) compressed with this package's encoder, C `lz4 -1`, and C `lz4 -12` show offsets 3–7 carry ≤ 2.2% of match bytes, and end-to-end decode of that corpus is unchanged within noise. The existing text/random/columnar benchmarks are likewise unchanged (±1%).

## Tests

- `TestMatchCopyMatrix` now sweeps offsets 5 and 6 (3, 4, and 7 were already swept at every match length 4–64, which crosses all prefill/tile/tail boundaries of the new paths).
- New `BenchmarkUncompressRLE5/6/7` cover the tile path periods.
- Full test suite passes on arm64 (Cortex-A72) and amd64.

Possible follow-up: the amd64 decoder byte-copies *all* overlapping matches (`offset < matchlen`), so it has a wider version of the same cliff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)