### PR TITLE
arm64: Neoverse-tuned match copies (sequenced shortcut, offset 8-31 tiles)

### DIFF
--- a/bench_rle_test.go
+++ b/bench_rle_test.go
@@ -56,13 +56,18 @@ func benchRLE(b *testing.B, period int) {
 	b.ReportMetric(float64(len(compressed))/float64(n), "compress_ratio")
 }
 
-func BenchmarkUncompressRLE1(b *testing.B) { benchRLE(b, 1) }
-func BenchmarkUncompressRLE2(b *testing.B) { benchRLE(b, 2) }
-func BenchmarkUncompressRLE5(b *testing.B) { benchRLE(b, 5) }
-func BenchmarkUncompressRLE6(b *testing.B) { benchRLE(b, 6) }
-func BenchmarkUncompressRLE7(b *testing.B) { benchRLE(b, 7) }
-func BenchmarkUncompressRLE3(b *testing.B) { benchRLE(b, 3) }
-func BenchmarkUncompressRLE4(b *testing.B) { benchRLE(b, 4) }
+func BenchmarkUncompressRLE1(b *testing.B)  { benchRLE(b, 1) }
+func BenchmarkUncompressRLE2(b *testing.B)  { benchRLE(b, 2) }
+func BenchmarkUncompressRLE5(b *testing.B)  { benchRLE(b, 5) }
+func BenchmarkUncompressRLE6(b *testing.B)  { benchRLE(b, 6) }
+func BenchmarkUncompressRLE7(b *testing.B)  { benchRLE(b, 7) }
+func BenchmarkUncompressRLE8(b *testing.B)  { benchRLE(b, 8) }
+func BenchmarkUncompressRLE12(b *testing.B) { benchRLE(b, 12) }
+func BenchmarkUncompressRLE16(b *testing.B) { benchRLE(b, 16) }
+func BenchmarkUncompressRLE24(b *testing.B) { benchRLE(b, 24) }
+func BenchmarkUncompressRLE31(b *testing.B) { benchRLE(b, 31) }
+func BenchmarkUncompressRLE3(b *testing.B)  { benchRLE(b, 3) }
+func BenchmarkUncompressRLE4(b *testing.B)  { benchRLE(b, 4) }
 
 // buildColumnar builds a synthetic input that mimics the match-length and
 // match-offset distribution typical of columnar / record-oriented compressed

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -96,32 +96,12 @@ loop:
 	CMP dstorig, match
 	BLO readMatchlen              // dict reference: use existing dict path.
 
-	// 18-byte match copy. dst-space is guaranteed: dst < dstend-32 and
-	// matchlen+minMatch <= 18. Bytes past matchlen+minMatch get
-	// overwritten next iter.
-	//
-	// For offset >= 18 there is no aliasing between [match, match+17]
-	// and [dst, dst+17], so LDP+STP can load all 16 bytes in parallel
-	// before any store retires -- 4 memory ops total instead of 6.
-	// Measurements on kibble-sourced columnar data (int64c/float64c/
-	// varstring.dictc/hexc) show ~95% of all matches have offset >= 18,
-	// so this is the common case.
-	//
-	// For offset 8..17 an LDP reads past the first store's destination,
-	// so we fall back to sequenced 8+8+2 so that each load observes
-	// the prior store's effect (required for offset == 8 RLE cycling).
-	CMP   $18, offset
-	BLO   shortcutMatchSerial
-
-	LDP   (match), (tmp1, tmp2)
-	MOVHU 16(match), tmp3
-	STP   (tmp1, tmp2), (dst)
-	MOVH  tmp3, 16(dst)
-	ADD   $const_minMatch, len
-	ADD   len, dst
-	B     copyMatchDone
-
-shortcutMatchSerial:
+	// 18-byte match copy as sequenced 8+8+2 (like the C decoder).
+	// dst-space is guaranteed: dst < dstend-32 and matchlen+minMatch
+	// <= 18; bytes past the match get overwritten next iter. 8-byte
+	// loads are more likely than an LDP to be forwarded from the
+	// in-flight stores of the previous sequences (Neoverse), and the
+	// sequencing keeps offset == 8 cycling correct.
 	MOVD  (match), tmp1
 	MOVD  tmp1, (dst)
 	MOVD  8(match), tmp2
@@ -260,13 +240,11 @@ copyDict:
 	SUB  dstorig, dst, offset
 
 copyMatchTry8:
-	// Non-overlapping bulk copy: len >= 64 and offset >= len means the
-	// whole match can be served by runtime.memmove, whose arm64
-	// implementation uses 128-bit NEON with prefetch and outruns any
-	// 16B/iter LDP+STP loop we can realistically write inline. Columnar
-	// / record-oriented workloads hit this case heavily (large offsets,
-	// match length ~record size). Below 64 bytes the call-and-spill
-	// overhead dominates, so the inline LDP/STP loop below stays.
+	// Non-overlapping bulk copy: len >= 256 and offset >= len means the
+	// whole match can be served by runtime.memmove (scalar 64B/iter
+	// LDP/STP with source alignment), which outruns the 16B/iter loop
+	// below for long copies. Below 256 bytes the call-and-spill
+	// overhead dominates, so the inline loops stay.
 	CMP  $256, len
 	BLO  copyMatchTry8_inline
 	CMP  len, offset
@@ -309,13 +287,28 @@ copyMatchLoop16:
 	B    copyMatchDone
 
 copyMatchTry8Narrow:
-	// 8-byte path for len >= 8 and offset in [8, 32). Preserves existing
-	// behavior for small offsets where the 16B loop would either alias
-	// (offset < 16) or incur per-iter STLF stalls (offset 16..31).
+	// Offsets in [8, 32) (or any offset >= 8 via the dict remainder
+	// path). Long matches take the load-free tiles; short ones the
+	// 8-byte loop.
 	CMP  $8, len
 	CCMP HS, offset, $8, $0
 	BLO  copyMatchTry4
 
+	CMP  $32, len
+	BLO  copyMatchLoop8Setup        // short match: 8-byte loop.
+	CMP  $32, offset
+	BHS  copyMatchLoop8Setup        // offset >= 32 only via the dict remainder path.
+	CMP  $8, offset
+	BEQ  copyMatchTile8
+	CMP  $16, offset
+	BEQ  copyMatchTile16
+	BLO  copyMatchTile              // 9..15: generic 16-byte tile (prefill = offset).
+	CMP  $24, offset
+	BEQ  copyMatchTile24
+	B    copyMatchTile32            // 17..23, 25..31: 32-byte tile.
+
+copyMatchLoop8Setup:
+	// 8-byte loop, store-to-load-forwarding bound; fine for short matches.
 	AND    $7, len, lenRem
 	SUB    $8, len
 copyMatchLoop8:
@@ -410,8 +403,74 @@ copyMatchTileLoop:
 
 copyMatchTileTail:
 	CBZ len, copyMatchDone
-	SUB offset, dst, match         // Re-derive match for the byte loop.
-	B   copyMatchByteLoop
+	SUB offset, dst, match         // Re-derive match for the tail copy.
+	CMP $8, len
+	BLO copyMatchByteLoop
+	B   copyMatchTry8Narrow
+
+	// Load-free tiles for offsets 8..31 with len >= 32 (constant or
+	// short-period columns): load the pattern once, then only store.
+copyMatchTile8:
+	// The splat loop consumes multiples of 8, so dst stays phase-aligned
+	// and its byte-loop tail (reading from the un-advanced match) is right.
+	MOVD (match), tmp3
+	B    copyMatchSplatLoop
+
+copyMatchTile16:
+	LDP (match), (tmp1, tmp2)
+copyMatchTile16Loop:
+	CMP   $16, len
+	BLO   copyMatchTileTail
+	STP.P (tmp1, tmp2), 16(dst)
+	SUB   $16, len
+	B     copyMatchTile16Loop
+
+copyMatchTile24:
+	// Dedicated tile: the generic 32-byte tile would overlap its stores
+	// by 8 bytes at this stride, which is markedly slower.
+	LDP  (match), (tmp1, tmp2)
+	MOVD 16(match), tmp3
+copyMatchTile24Loop:
+	CMP  $24, len
+	BLO  copyMatchTileTail
+	STP  (tmp1, tmp2), (dst)
+	MOVD tmp3, 16(dst)
+	ADD  $24, dst
+	SUB  $24, len
+	B    copyMatchTile24Loop
+
+copyMatchTile32:
+	// offset in 17..23, 25..31: prefill one period (8-byte copies never
+	// read ahead of the writes since offset >= 8), so [dst-2*offset, dst)
+	// holds two periods (>= 34 bytes) and dst is phase-aligned; then
+	// store a 32-byte tile from there, advancing by offset. The overlap
+	// between consecutive stores is rewritten with identical bytes.
+	MOVD offset, tmp4
+copyMatchTile32Pre8:
+	MOVD.P 8(match), tmp1
+	MOVD.P tmp1, 8(dst)
+	SUB    $8, tmp4
+	CMP    $8, tmp4
+	BHS    copyMatchTile32Pre8
+	CBZ    tmp4, copyMatchTile32Load
+copyMatchTile32Pre1:
+	MOVBU.P 1(match), tmp1
+	MOVB.P  tmp1, 1(dst)
+	SUBS    $1, tmp4
+	BNE     copyMatchTile32Pre1
+copyMatchTile32Load:
+	SUB offset, len
+	SUB offset<<1, dst, lenRem     // lenRem = dst - 2*offset: tile source.
+	LDP (lenRem), (tmp1, tmp2)
+	LDP 16(lenRem), (tmp3, tmp4)
+copyMatchTile32Loop:
+	CMP $32, len
+	BLO copyMatchTileTail
+	STP (tmp1, tmp2), (dst)
+	STP (tmp3, tmp4), 16(dst)
+	ADD offset, dst
+	SUB offset, len
+	B   copyMatchTile32Loop
 
 copyMatchSplat2:
 	// offset == 2: splat a halfword.
@@ -425,6 +484,11 @@ copyMatchSplatTile32:
 	// every later core, and Apple M-series) can retire an STP of two
 	// X-registers as a single 16-byte store; doubling the store width
 	// halves the iteration count and the per-iteration loop overhead.
+	//
+	// PCALIGN bumps decodeBlock's own alignment to 64B, fixing a 2-3% M4
+	// regression the tile paths above caused in offset 1-7 code below by
+	// shifting it off-alignment.
+	PCALIGN $64
 copyMatchSplatLoop:
 	CMP    $16, len
 	BLO    copyMatchSplatTail

--- a/internal/lz4block/match_copy_test.go
+++ b/internal/lz4block/match_copy_test.go
@@ -86,7 +86,15 @@ func TestMatchCopySingle(t *testing.T) {
 		{"off4_len8", 4, 8, 64},           // word-splat path
 		{"off8_len8", 8, 8, 64},           // shortcut 8+8+2 boundary
 		{"off8_len18", 8, 18, 64},         // shortcut + match-len boundary
-		{"off8_len32", 8, 32, 64},         // copyMatchLoop8 at offset=8
+		{"off8_len31", 8, 31, 64},         // copyMatchLoop8 at offset=8 (below tile threshold)
+		{"off8_len32", 8, 32, 64},         // offset-8 tile: exactly the threshold
+		{"off8_len100", 8, 100, 64},       // offset-8 tile with 8B + byte tail
+		{"off16_len32", 16, 32, 64},       // offset-16 tile, no tail
+		{"off16_len47", 16, 47, 64},       // offset-16 tile with 15-byte tail
+		{"off12_len64", 12, 64, 64},       // 9..15 generic tile (prefill 12)
+		{"off17_len32", 17, 32, 64},       // 32B tile: prefill 17 = 2x8 + 1, no tile iteration
+		{"off24_len96", 24, 96, 64},       // 32B tile: prefill 3x8, three iterations
+		{"off31_len4096", 31, 4096, 64},   // 32B tile: long
 		{"off16_len16", 16, 16, 64},       // offset >= 16 but < 32
 		{"off16_len100", 16, 100, 64},     // offset < 32: must use 8B loop
 		{"off32_len16", 32, 16, 64},       // smallest 16B-eligible
@@ -122,17 +130,23 @@ func TestMatchCopySingle(t *testing.T) {
 // most likely to expose addressing-mode or threshold bugs. Each combination
 // is decoded and diffed against the naive reference built in memory.
 func TestMatchCopyMatrix(t *testing.T) {
-	// Offsets: cover 1..7 (below the 8-byte threshold), 8..31 (below 16B
-	// threshold), and 32+ (16B eligible). Include the exact threshold
-	// points plus a scattering above.
-	offsets := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 32, 33, 48, 64, 127, 128, 255, 1024}
+	// Offsets: cover 1..7 (splat/tile paths), every offset in 8..31 (the
+	// 8-byte loop and the offset-8/16/9..15/17..31 tile paths, whose
+	// prefill and tail handling depend on offset%8 and on the exact
+	// remaining length), and 32+ (16B loop / memmove). Include the exact
+	// threshold points plus a scattering above.
+	offsets := []int{1, 2, 3, 4, 5, 6, 7}
+	for o := 8; o <= 33; o++ {
+		offsets = append(offsets, o)
+	}
+	offsets = append(offsets, 48, 64, 127, 128, 255, 1024)
 	// Match lengths: every integer from 4..64 catches off-by-one issues in
 	// all the loops; then a few large values exercise the bulk-copy path.
 	var mlens []int
 	for l := minMatch; l <= 64; l++ {
 		mlens = append(mlens, l)
 	}
-	mlens = append(mlens, 100, 255, 256, 1023, 4096)
+	mlens = append(mlens, 65, 66, 71, 72, 79, 80, 95, 96, 100, 127, 128, 255, 256, 1023, 4096)
 
 	for _, off := range offsets {
 		for _, mlen := range mlens {


### PR DESCRIPTION
## What

Two changes to `decode_arm64.s`, both measured against the reference C decoder (lz4 1.10, `LZ4_decompress_safe` on identical compressed bytes) on Neoverse N1 — Ampere Altra and Graviton2 — which is the production target for this code. The earlier arm64 work was tuned on a Cortex-A72; this revisits two choices where N1 behaves differently.

1. **Shortcut match copy: sequenced 8+8+2 for every offset ≥ 8** (as the C decoder does), replacing the LDP+MOVHU form used for offset ≥ 18. The match source was usually written by the previous one or two sequences and is still in the store buffer. On Neoverse an 8-byte load is far more likely than a 16-byte LDP to be fully contained in a single in-flight store — and thus forwarded — instead of stalling until the stores drain to L1. Instruction-level profiling on dictionary-string data showed the old variant's trailing `MOVHU 16(match)` at 31% of decode time.

2. **Load-free tile paths for long matches (≥ 32 B) at offsets 8..31.** This is how a constant or short-period column encodes (a constant int64/float64 column is one offset-8 match spanning the column). Previously these went through the 8-byte loop, where every load waits on a store from a few iterations back (~1–2 B/cycle). Now: offset 8 reuses the 16-byte splat store loop; 16 and 24 store their pattern from registers; 9..15 reuse the offset-3..7 tile from #246; 17..31 prefill one period then store a 32-byte tile advancing by `offset`.

Also corrects the memmove comment: `runtime.memmove` on arm64 is a scalar 64 B/iter LDP/STP loop with source alignment, not NEON.

## Measurements (Neoverse N1 / Ampere Altra, pinned, identical inputs)

| | before | after |
|---|---|---|
| 1 MiB run, period 8 | 5.0 GB/s | 21.7 GB/s |
| period 16 | 10.9 | 21.7 |
| period 24 | 12.0 | 31.2 |
| periods 1–7, 64 | 19–23 | unchanged |
| dictionary-string column | 2262 MB/s | 2523 (+11.5%) |
| few-distinct-value float64 column | 1624 | 1898 (+16.9%) |
| English text (twain / pg1661) | 2348 / 2324 | 2519 / 2492 (+7%) |
| ELF (bash) | 2481 | 2591 (+4.4%) |
| JSON logs | 2541 | 2563 (+0.9%) |
| long-record columnar, hex, int64 | | within noise |

Graviton2 shows the same shape (periods 8/16/24 at 17.8/18.0/25.7 GB/s). Cortex-A72 marginally preferred the old LDP shortcut form (it was measured there when #243 landed); Neoverse is the target and the A72 difference was small.

## Local verification (Apple M4, arm64, darwin)

Ran the two commits (base `a5888c7` vs. this PR's `c618f0c`) as separate static `go test -c` binaries, alternating rounds (before/after/before/after…, 8 rounds, `-benchtime=300ms` each) to cancel out thermal/frequency drift, then compared with `benchstat`.

| benchmark | before | after | Δ throughput |
|---|---|---|---|
| RLE8 (offset 8) | 9.93 GiB/s ± 50% | 52.66 GiB/s ± 1% | **+430%** (p<0.001) |
| RLE12 (offset 12) | 4.80 GiB/s ± 2% | 39.33 GiB/s ± 4% | **+720%** (p<0.001) |
| RLE16 (offset 16) | 28.87 GiB/s ± 1% | 53.45 GiB/s ± 28% | **+85%** (p<0.001) |
| RLE24 (offset 24) | 28.69 GiB/s ± 1% | 60.82 GiB/s ± 2% | **+112%** (p<0.001) |
| RLE31 (offset 31) | 9.46 GiB/s ± 1% | 52.11 GiB/s ± 2% | **+451%** (p<0.001) |
| RLE1/2/3/4/5/6/7 (offset < 8, untouched by this change) | — | — | fixed, see below |
| Twain / pg1661 / digits / rand / columnar-{short,med,long} | — | — | ~noise, mostly p>0.05 |

Confirms the qualitative shape of the N1/Graviton2 numbers above — large win concentrated at offsets 8..31, flat elsewhere — though the magnitude differs per offset (M4 jumps more at offset 8, less at 16) and the *before* numbers at offsets 8/12/31 were themselves highly variable (±47-50%), consistent with the PR's own store-to-load-forwarding-stall diagnosis: those paths were timing-sensitive before this change and are not after.

**Update:** offsets 1-7 (splat/generic paths this PR doesn't touch) initially showed a small but statistically significant ~2-3% regression on M4 (p<0.01, tight variance) — surprising since that code is byte-for-byte unchanged. Root cause: adding the offset 8-31 tile paths shifted every loop after them by a few bytes, and `decodeBlock` wasn't 64-byte aligned to begin with, so the shift moved the untouched loops into a worse spot. Confirmed by testing each loop's own alignment directly (no effect) versus realigning the whole function (fixed everything) — added a `PCALIGN $64` before `copyMatchSplatLoop`, which as a side effect bumps `decodeBlock`'s function alignment to 64B. With it, offsets 1-7 are statistically indistinguishable from pre-PR (p>0.06 across the board) and the offset 8-31 wins above are undisturbed (small additional +2-4%, same noise band).

`TestMatchCopyMatrix`, `TestMatchCopySingle`, and the full suite (`go test ./...`) all pass on this branch.

## Tests

- `TestMatchCopyMatrix` now sweeps **every** offset 8..33 (covers all tile prefill/tail phases, `offset%8`) with all lengths 4..64 plus extra lengths around 64..128, 255/256, 1023, 4096.
- `TestMatchCopySingle` gains cases at each new path's threshold and tail (offset 8 at len 31/32/100, 16 at 32/47, 12 at 64, 17 at 32, 24 at 96, 31 at 4096).
- New `BenchmarkUncompressRLE8/12/16/24/31`.
- Native round-trip fuzzing (structured inputs through the real compressor, all periods) and mutation fuzzing with canary bounds checks: 3 minutes clean on N1 (run locally, not committed).
- Full suite passes on Ampere Altra and Graviton2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
