### PR TITLE
xxh32: select Sum32's hash path using the untruncated length

### DIFF
--- a/internal/xxh32/xxh32zero.go
+++ b/internal/xxh32/xxh32zero.go
@@ -111,7 +111,10 @@ func updateGo(v *[4]uint32, buf *[16]byte, input []byte) {
 // Sum32 returns the 32 bits Hash value.
 func (xxh *XXHZero) Sum32() uint32 {
 	h32 := uint32(xxh.totalLen)
-	if h32 >= 16 {
+	// The length term is taken modulo 2^32, but whether the accumulator lanes
+	// are folded in depends on the true length: a 4 GiB input is not a short
+	// input even though its truncated length is 0.
+	if xxh.totalLen >= 16 {
 		h32 += rol1(xxh.v[0]) + rol7(xxh.v[1]) + rol12(xxh.v[2]) + rol18(xxh.v[3])
 	} else {
 		h32 += prime5

--- a/internal/xxh32/xxh32zero.go
+++ b/internal/xxh32/xxh32zero.go
@@ -110,10 +110,10 @@ func updateGo(v *[4]uint32, buf *[16]byte, input []byte) {
 
 // Sum32 returns the 32 bits Hash value.
 func (xxh *XXHZero) Sum32() uint32 {
-	h32 := uint32(xxh.totalLen)
 	// The length term is taken modulo 2^32, but whether the accumulator lanes
 	// are folded in depends on the true length: a 4 GiB input is not a short
 	// input even though its truncated length is 0.
+	h32 := uint32(xxh.totalLen)
 	if xxh.totalLen >= 16 {
 		h32 += rol1(xxh.v[0]) + rol7(xxh.v[1]) + rol12(xxh.v[2]) + rol18(xxh.v[3])
 	} else {

--- a/internal/xxh32/xxh32zero_large_test.go
+++ b/internal/xxh32/xxh32zero_large_test.go
@@ -1,0 +1,51 @@
+//go:build !race
+
+package xxh32_test
+
+import (
+	"testing"
+
+	"github.com/pierrec/lz4/v4/internal/xxh32"
+)
+
+// TestZeroLargeInput covers inputs whose length does not fit in 32 bits.
+// Sum32 adds the length modulo 2^32, but it must choose between the
+// accumulator and the short-input path on the true length: 4 GiB is not a
+// short input even though its truncated length is 0.
+//
+// The second case leaves a non-empty tail buffer, and because the remainder is
+// written first, every subsequent write carries buffered bytes across the call
+// boundary.
+//
+// The sums are the reference C implementation's frame content checksum and can
+// be regenerated with:
+//
+//	head -c 4294967296 /dev/zero | lz4 -c | tail -c 4 | xxd -p  # 4139b935 -> 0x35b93941
+//	head -c 4294967301 /dev/zero | lz4 -c | tail -c 4 | xxd -p  # 21cba38e -> 0x8ea3cb21
+//
+// It is built only without -race: hashing several GiB is roughly 60 times
+// slower under the race detector, and there is no concurrency here to check.
+func TestZeroLargeInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("hashes several GiB")
+	}
+	const fourGiB = int64(1) << 32
+	block := make([]byte, 1<<20)
+	for _, td := range []struct {
+		sum uint32
+		n   int64
+	}{
+		{0x35b93941, fourGiB},
+		{0x8ea3cb21, fourGiB + 5},
+	} {
+		var xxh xxh32.XXHZero
+		rem := td.n % int64(len(block))
+		_, _ = xxh.Write(block[:rem])
+		for written := rem; written < td.n; written += int64(len(block)) {
+			_, _ = xxh.Write(block)
+		}
+		if got, want := xxh.Sum32(), td.sum; got != want {
+			t.Errorf("%d bytes: got %x; want %x", td.n, got, want)
+		}
+	}
+}

--- a/internal/xxh32/xxh32zero_test.go
+++ b/internal/xxh32/xxh32zero_test.go
@@ -146,36 +146,9 @@ func TestUnaligned(t *testing.T) {
 	}
 }
 
-// Inputs whose length is a multiple of 2^32 sit on the boundary between Sum32's
-// short-input and accumulator paths. xxHash32 adds the length modulo 2^32, but
-// the choice of path must be made on the true length: 4 GiB is not a short
-// input, even though its truncated length is 0. Sums are from the reference C
-// implementation (the lz4 CLI's frame content checksum over the same input).
-func TestZeroLargeInput(t *testing.T) {
-	if testing.Short() {
-		t.Skip("hashes several GiB")
-	}
-	const fourGiB = int64(1) << 32
-	for _, td := range []struct {
-		sum uint32
-		n   int64
-	}{
-		{0x35b93941, fourGiB},
-		{0xfd20b641, 2 * fourGiB},
-	} {
-		var xxh xxh32.XXHZero
-		block := make([]byte, 1<<20)
-		for written := int64(0); written < td.n; written += int64(len(block)) {
-			_, _ = xxh.Write(block)
-		}
-		if got, want := xxh.Sum32(), td.sum; got != want {
-			t.Errorf("%d bytes: got %x; want %x", td.n, got, want)
-		}
-	}
-}
-
-// /////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 // Benchmarks
+//
 var testdata1 = []byte(testdata[len(testdata)-1].data)
 
 func Benchmark_XXH32(b *testing.B) {

--- a/internal/xxh32/xxh32zero_test.go
+++ b/internal/xxh32/xxh32zero_test.go
@@ -146,9 +146,36 @@ func TestUnaligned(t *testing.T) {
 	}
 }
 
-///////////////////////////////////////////////////////////////////////////////
+// Inputs whose length is a multiple of 2^32 sit on the boundary between Sum32's
+// short-input and accumulator paths. xxHash32 adds the length modulo 2^32, but
+// the choice of path must be made on the true length: 4 GiB is not a short
+// input, even though its truncated length is 0. Sums are from the reference C
+// implementation (the lz4 CLI's frame content checksum over the same input).
+func TestZeroLargeInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("hashes several GiB")
+	}
+	const fourGiB = int64(1) << 32
+	for _, td := range []struct {
+		sum uint32
+		n   int64
+	}{
+		{0x35b93941, fourGiB},
+		{0xfd20b641, 2 * fourGiB},
+	} {
+		var xxh xxh32.XXHZero
+		block := make([]byte, 1<<20)
+		for written := int64(0); written < td.n; written += int64(len(block)) {
+			_, _ = xxh.Write(block)
+		}
+		if got, want := xxh.Sum32(), td.sum; got != want {
+			t.Errorf("%d bytes: got %x; want %x", td.n, got, want)
+		}
+	}
+}
+
+// /////////////////////////////////////////////////////////////////////////////
 // Benchmarks
-//
 var testdata1 = []byte(testdata[len(testdata)-1].data)
 
 func Benchmark_XXH32(b *testing.B) {


### PR DESCRIPTION
## The problem

`XXHZero.Sum32` picks between xxHash32's accumulator and short-input paths using the stream length **truncated to 32 bits**:

```go
h32 := uint32(xxh.totalLen)   // totalLen is uint64
if h32 >= 16 {                // regime test on the truncated value
```

Adding `length mod 2^32` is correct per the spec, but the *regime* decision must be made on the true length. Any stream whose length is congruent to `0..15 (mod 2^32)` takes the short-input path and discards every accumulator lane. At an exact multiple of 4 GiB the result is `0x02cc5d05` — the xxHash32 of the **empty input** — regardless of content.

lz4 uses this hash for the frame content checksum, so the consequence is that frames whose uncompressed size is a multiple of 4 GiB do not interoperate with the reference C implementation in either direction.

## The fix

One line, `internal/xxh32/xxh32zero.go`:

```diff
-	if h32 >= 16 {
+	if xxh.totalLen >= 16 {
```

This is equivalent to what the C reference does. It keeps a **sticky** `large_len` flag (`state->large_len |= (len>=16) | (state->total_len_32>=16)`) and branches on that at digest time; its own counter wraps too, but the flag latches and never clears. The Go port had replaced that latch with a predicate recomputed from a wrapping counter. Since `totalLen` is a `uint64` that only increases, testing it directly restores the equivalence.

`Sum32` has no assembly variants, so this single edit covers every architecture. The one-shot `checksumZeroGo` was never affected — it branches on an untruncated `int`.

## Verification

Cross-implementation, same content (4 GiB of zeros), against reference C `lz4` v1.9.4:

| writer | reader | before | after |
| --- | --- | --- | --- |
| C lz4 | this library | FAIL `got 2cc5d05; expected 35b93941` | **PASS** |
| this library | C lz4 | FAIL exit 66 `ERROR_contentChecksum_invalid` | **PASS** |
| this library | this library | PASS | PASS |

## The commits

- `6052a21` — the one-line fix plus `TestZeroLargeInput`.
- `caa2992` — review follow-ups: gave the test tail-path coverage, took it off `-race`, and reverted stray gofmt churn.

Two commits for reviewability; squash on merge.

### On the test

`TestZeroLargeInput` lives in its own file behind `//go:build !race`. It hashes several GiB, which the race detector slows by ~60x (1.3s → 78s measured), and `ci.yml` runs the suite twice with `-race` across a 3-OS × 3-Go matrix — that would have added roughly 23 minutes per PR to a suite that otherwise finishes in under two seconds. The test exercises no concurrency, so the detector has nothing to check in it. Added cost is now ~1.9s per job.

Its expected sums come from the reference C implementation, not from a Go reimplementation — a round-trip test cannot catch a symmetric bug in a shared helper. The regeneration commands are in the test's comment.

Fixes: #249 