### PR TITLE
Write the buffered remainder in Reader.WriteTo

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -241,6 +241,18 @@ func (r *Reader) WriteTo(w io.Writer) (n int64, err error) {
 	}
 	defer r.state.nextd(&err)
 
+	if r.idx > 0 {
+		// A previous Read left part of the current block unconsumed.
+		var bn int
+		bn, err = w.Write(r.data[r.idx:])
+		n += int64(bn)
+		r.idx = 0
+		if err != nil {
+			return
+		}
+		r.handler(bn)
+	}
+
 	var data []byte
 	if r.isNotConcurrent() {
 		size := r.frame.Descriptor.Flags.BlockSizeIndex()

--- a/reader_test.go
+++ b/reader_test.go
@@ -362,6 +362,30 @@ func TestReader_WriteTo(t *testing.T) {
 	}
 }
 
+func TestReader_WriteToAfterPartialRead(t *testing.T) {
+	for _, conc := range []int{1, 4} {
+		zr := lz4.NewReader(bytes.NewReader(pg1661LZ4))
+		zr.Apply(lz4.ConcurrencyOption(conc))
+
+		const prefix = 10
+		if _, err := io.ReadFull(zr, make([]byte, prefix)); err != nil {
+			t.Fatalf("concurrency=%d: %v", conc, err)
+		}
+
+		buf := new(bytes.Buffer)
+		n, err := zr.WriteTo(buf)
+		if err != nil {
+			t.Fatalf("concurrency=%d: %v", conc, err)
+		}
+		if want := int64(len(pg1661) - prefix); n != want {
+			t.Fatalf("concurrency=%d: expecting to write %d bytes, got %d", conc, want, n)
+		}
+		if !reflect.DeepEqual(buf.Bytes(), pg1661[prefix:]) {
+			t.Fatalf("concurrency=%d: result does not match original", conc)
+		}
+	}
+}
+
 // TestReader_DirectModeStaleData verifies that a zero-length uncompressed block
 // in direct mode does not cause stale pool data to be returned. Before the fix,
 // r.data was not cleared after a direct-mode decompress, so a subsequent


### PR DESCRIPTION
`io.Copy` from a `Reader` that has already been partially read returns 0 and a nil error, dropping
everything that was left.

```go
zr := lz4.NewReader(compressed)
io.ReadFull(zr, make([]byte, 10))   // read a small prefix
n, err := io.Copy(dst, zr)          // uses WriteTo
```

```
prefix=1     io.Copy(WriteTo)=0  err=<nil>   io.Copy(Read)=199999   want=199999
prefix=10    io.Copy(WriteTo)=0  err=<nil>   io.Copy(Read)=199990   want=199990
prefix=1000  io.Copy(WriteTo)=0  err=<nil>   io.Copy(Read)=199000   want=199000
```

The right-hand column is the same `io.Copy` with `WriteTo` hidden behind a wrapper so it takes the
`Read` path — that one is correct, which is what makes this a silent divergence rather than a
visible failure.

### Cause

`Read` decompresses a whole block into `r.data` and hands out a slice of it, leaving the remainder
at `r.data[r.idx:]` (`reader.go:161`). `WriteTo` (`reader.go:230`) never looks at `r.idx`; it goes
straight to fetching the next block. When the current block is the last one that fetch returns
`io.EOF`, so `WriteTo` reports `(0, nil)`.

`io.Copy` documents that it uses `WriteTo` when the source implements `io.WriterTo`, so the two
paths have to agree — and `io.WriterTo` requires writing "until there's no more data to write".
The doc comment at `reader.go:229` states no limitation.

### Change

Drain the buffered remainder before entering the block loop:

```go
if r.idx > 0 {
    // A previous Read left part of the current block unconsumed.
    var bn int
    bn, err = w.Write(r.data[r.idx:])
    n += int64(bn)
    r.idx = 0
    if err != nil {
        return
    }
    r.handler(bn)
}
```

### Why the existing test misses it

`TestReader_WriteTo` (`reader_test.go:337`) reads the header with `zr.Read(nil)` — a zero-byte read,
so `r.idx` stays 0 and the path is never entered. That test came in with #227 ("Fix WriteTo on a
started Reader"), which fixed the adjacent case where `WriteTo` was called after the frame had been
initialised; this is the case where actual bytes were consumed.

A test is added next to it that reads a 10-byte prefix first, at concurrency 1 and 4, using the
existing `pg1661LZ4` fixture. Red with only `reader.go` reverted
(`expecting to write 594923 bytes, got 0`), green with the change.

All four CI configurations pass — `go test ./...`, `-race`, `-tags noasm`, `-race -tags noasm` —
and `gofmt -l` lists neither changed file.

---

Disclosure: prepared with AI assistance; I verified the reproduction, the `Read`-path comparison and
the red/green runs myself.
