### PR TITLE
amd64/arm64: faster match copies in the assembly decoders

### DIFF
--- a/bench_rle_test.go
+++ b/bench_rle_test.go
@@ -69,6 +69,10 @@ func BenchmarkUncompressRLE31(b *testing.B) { benchRLE(b, 31) }
 func BenchmarkUncompressRLE3(b *testing.B)  { benchRLE(b, 3) }
 func BenchmarkUncompressRLE4(b *testing.B)  { benchRLE(b, 4) }
 
+// Overlapping offsets beyond the register tiles.
+func BenchmarkUncompressRLE48(b *testing.B) { benchRLE(b, 48) }
+func BenchmarkUncompressRLE64(b *testing.B) { benchRLE(b, 64) }
+
 // buildColumnar builds a synthetic input that mimics the match-length and
 // match-offset distribution typical of columnar / record-oriented compressed
 // storage. Columnar data tends to have two distinct populations: many short
@@ -142,6 +146,15 @@ func BenchmarkUncompressColumnarLong(b *testing.B) {
 
 // Smaller records -- pushes typical match length down toward 64 bytes, so
 // the shortcut's 18-byte copy fires more often than the long-match loop.
+// Between Short (64) and Med (512): locates the inline-vs-memmove crossover.
+func BenchmarkUncompressColumnar128(b *testing.B) {
+	benchColumnar(b, 1<<20, 128, 256)
+}
+
+func BenchmarkUncompressColumnar256(b *testing.B) {
+	benchColumnar(b, 1<<20, 256, 128)
+}
+
 func BenchmarkUncompressColumnarShort(b *testing.B) {
 	benchColumnar(b, 1<<20, 64, 256)
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -58,16 +58,34 @@ func BenchmarkCompressHC(b *testing.B) {
 	}
 }
 
-func BenchmarkUncompress(b *testing.B) {
-	buf := make([]byte, len(pg1661))
+// benchmarkUncompressBlock measures the block decoder alone: no frame, no checksum.
+func benchmarkUncompressBlock(b *testing.B, raw []byte) {
+	block := make([]byte, lz4.CompressBlockBound(len(raw)))
+	var c lz4.Compressor
+	n, err := c.CompressBlock(raw, block)
+	if err != nil {
+		b.Fatal(err)
+	}
+	block = block[:n]
+	buf := make([]byte, len(raw))
 
+	b.SetBytes(int64(len(raw)))
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = lz4block.UncompressBlock(pg1661LZ4, buf, nil)
+		if _, err := lz4block.UncompressBlock(block, buf, nil); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
+
+func BenchmarkUncompress(b *testing.B) { benchmarkUncompressBlock(b, pg1661) }
+
+// bzImage is half literal bytes, so it exercises what text skips through
+// the shortcut. Its golden .lz4 is a legacy frame with trailing data, so
+// decode it as a block.
+func BenchmarkUncompressBzImage(b *testing.B) { benchmarkUncompressBlock(b, bzImage) }
 
 func mustLoadFile(f string) []byte {
 	var b []byte
@@ -93,6 +111,7 @@ var (
 	twainLZ4          = mustLoadFile("testdata/Mark.Twain-Tom.Sawyer.txt.lz4")
 	randomLZ4         = mustLoadFile("testdata/random.data.lz4")
 	randomAppendedLZ4 = mustLoadFile("testdata/random_appended.data.lz4")
+	bzImage           = mustLoadFile("testdata/bzImage_lz4_isolated.gz")
 )
 
 func benchmarkUncompress(b *testing.B, compressed []byte) {

--- a/internal/lz4block/decode_amd64.s
+++ b/internal/lz4block/decode_amd64.s
@@ -6,9 +6,11 @@
 #include "textflag.h"
 
 // AX scratch
-// BX scratch
+// BX scratch, match pointer
 // CX literal and match lengths
 // DX token, match offset
+// R10 scratch (match copy)
+// X0, X1 scratch (match copy)
 //
 // DI &dst
 // SI &src
@@ -272,23 +274,34 @@ copy_match:
 	// if BX < &dst
 	JC copy_match_from_dict
 	CMPQ BX, R11
-	JBE copy_match_from_dict
+	JB copy_match_from_dict
 
-	// if offset + match_len < di
-	LEAQ (BX)(CX*1), AX
-	CMPQ DI, AX
-	JA copy_interior_match
+copy_match_dispatch:
+	// DX offset, CX match_len > 0, BX match, DI dst. Also entered from
+	// copy_match_from_dict with BX = &dst, DX = di.
+	CMPQ DX, CX
+	JB   copy_match_overlap
 
-	// AX := len(dst[:di])
-	// MOVQ DI, AX
-	// SUBQ R11, AX
+	// Non-overlapping match (offset >= match_len).
+	CMPQ CX, $16
+	JA   copy_match_nonoverlap_long
 
-	// copy 16 bytes at a time
-	// if di-offset < 16 copy 16-(di-offset) bytes to di
-	// then do the remaining
+	// match_len <= 16: one 16-byte copy if there is room for the overrun.
+	// if len(dst[di:]) < 16
+	MOVQ R8, AX
+	SUBQ DI, AX
+	CMPQ AX, $16
+	JB   copy_match_loop
+
+	MOVOU (BX), X0
+	MOVOU X0, (DI)
+
+	ADDQ CX, DI
+	XORL CX, CX
+	JMP  loopcheck
 
 copy_match_loop:
-	// for match_len >= 0
+	// Byte copy: short overlapping matches and tails without room to overrun.
 	// dst[di] = dst[i]
 	// di++
 	// i++
@@ -301,22 +314,184 @@ copy_match_loop:
 
 	JMP loopcheck
 
-copy_interior_match:
-	CMPQ CX, $16
-	JGT memmove_match
+copy_match_nonoverlap_long:
+	// 17..255 bytes: inline 16-byte loop, last chunk ends exactly at
+	// di+match_len. 256 and up still call memmove.
+	CMPQ CX, $256
+	JAE  memmove_match
 
-	// if len(dst[di:]) < 16
-	MOVQ R8, AX
-	SUBQ DI, AX
-	CMPQ AX, $16
-	JLT memmove_match
-
+	MOVOU -16(BX)(CX*1), X1 // tail; the match does not overlap, so load it up front
+	LEAQ  -16(DI)(CX*1), R10
+copy_match_nonoverlap_loop:
 	MOVOU (BX), X0
 	MOVOU X0, (DI)
+	ADDQ  $16, BX
+	ADDQ  $16, DI
+	CMPQ  DI, R10
+	JB    copy_match_nonoverlap_loop
 
-	ADDQ CX, DI
-	XORL CX, CX
-	JMP  loopcheck
+	MOVOU X1, (R10)
+	LEAQ  16(R10), DI
+	XORL  CX, CX
+	JMP   loopcheck
+
+copy_match_overlap:
+	// Overlapping: the output is periodic with period offset.
+	CMPQ DX, $32
+	JAE  copy_match_overlap32
+	CMPQ DX, $16
+	JA   copy_match_overlap17 // 17..31
+	JE   copy_match_splat16
+
+	// offset < 16: byte loop if short, else splat (1, 2, 4, 8) or tile.
+	CMPQ CX, $16
+	JB   copy_match_loop
+	CMPQ DX, $8
+	JA   copy_match_tile // 9..15
+	JE   copy_match_splat8
+	CMPQ DX, $4
+	JA   copy_match_tile // 5, 6, 7
+	JE   copy_match_splat4
+	CMPQ DX, $2
+	JA   copy_match_tile // 3
+	JE   copy_match_splat2
+
+	// offset == 1: replicate the byte across X0.
+	MOVBQZX    (BX), AX
+	MOVQ       $0x0101010101010101, R10
+	IMULQ      R10, AX
+	MOVQ       AX, X0
+	PUNPCKLQDQ X0, X0
+	MOVQ       $16, R10
+	JMP        copy_match_tile_loop
+
+copy_match_splat2:
+	MOVWQZX    (BX), AX
+	MOVQ       $0x0001000100010001, R10
+	IMULQ      R10, AX
+	MOVQ       AX, X0
+	PUNPCKLQDQ X0, X0
+	MOVQ       $16, R10
+	JMP        copy_match_tile_loop
+
+copy_match_splat4:
+	MOVL   (BX), X0
+	PSHUFD $0, X0, X0
+	MOVQ   $16, R10
+	JMP    copy_match_tile_loop
+
+copy_match_splat8:
+	MOVQ       (BX), X0
+	PUNPCKLQDQ X0, X0
+	MOVQ       $16, R10
+	JMP        copy_match_tile_loop
+
+copy_match_splat16:
+	MOVOU (BX), X0
+	MOVQ  $16, R10
+	JMP   copy_match_tile_loop
+
+copy_match_tile:
+	// Prefill step = (16/offset)*offset bytes so [match, di) holds a full
+	// tile and di is phase-aligned; then store the tile every step bytes.
+	LEAQ    tileStep<>(SB), R10
+	MOVBQZX (R10)(DX*1), R10
+	SUBQ    R10, CX
+	LEAQ    (DI)(R10*1), AX // prefill end
+copy_match_tile_prefill:
+	MOVB (BX), R10
+	MOVB R10, (DI)
+	INCQ BX
+	INCQ DI
+	CMPQ DI, AX
+	JB   copy_match_tile_prefill
+
+	LEAQ    tileStep<>(SB), R10
+	MOVBQZX (R10)(DX*1), R10
+	MOVQ    DI, AX
+	SUBQ    R10, AX
+	SUBQ    DX, AX // AX = match: the tile source
+	MOVOU   (AX), X0
+
+copy_match_tile_loop:
+	// X0 tile, R10 step (16 for splats), CX bytes left.
+	CMPQ  CX, $16
+	JB    copy_match_tile_tail
+	MOVOU X0, (DI)
+	ADDQ  R10, DI
+	SUBQ  R10, CX
+	JMP   copy_match_tile_loop
+
+copy_match_tile_tail:
+	// 0..15 left: one more tile if it fits in dst, else bytes.
+	TESTQ CX, CX
+	JZ    loopcheck
+	MOVQ  R8, AX
+	SUBQ  DI, AX
+	CMPQ  AX, $16
+	JB    copy_match_tail_bytes
+	MOVOU X0, (DI)
+	ADDQ  CX, DI
+	XORL  CX, CX
+	JMP   loopcheck
+
+copy_match_tail_bytes:
+	MOVQ DI, BX
+	SUBQ DX, BX
+	JMP  copy_match_loop
+
+copy_match_overlap17:
+	// 17..31: prefill one period with two 16-byte copies (both inside
+	// [di, di+offset)), then store the 32-byte tile at match every offset bytes.
+	MOVOU (BX), X0
+	MOVOU X0, (DI)
+	MOVOU -16(BX)(DX*1), X1
+	MOVOU X1, -16(DI)(DX*1)
+	ADDQ  DX, DI
+	SUBQ  DX, CX
+	MOVOU 16(BX), X1
+
+copy_match_overlap17_loop:
+	CMPQ  CX, $32
+	JB    copy_match_overlap17_tail
+	MOVOU X0, (DI)
+	MOVOU X1, 16(DI)
+	ADDQ  DX, DI
+	SUBQ  DX, CX
+	JMP   copy_match_overlap17_loop
+
+copy_match_overlap17_tail:
+	// 0..31 left: one more tile if it fits in dst, else bytes.
+	TESTQ CX, CX
+	JZ    loopcheck
+	MOVQ  R8, AX
+	SUBQ  DI, AX
+	CMPQ  AX, $32
+	JB    copy_match_tail_bytes
+	MOVOU X0, (DI)
+	MOVOU X1, 16(DI)
+	ADDQ  CX, DI
+	XORL  CX, CX
+	JMP   loopcheck
+
+copy_match_overlap32:
+	// offset >= 32: loads never touch the previous iteration's store. The
+	// last chunk ends exactly at di+match_len and is loaded after the loop.
+	LEAQ -16(DI)(CX*1), R10
+	LEAQ -16(BX)(CX*1), AX
+copy_match_overlap32_loop:
+	MOVOU (BX), X0
+	MOVOU X0, (DI)
+	ADDQ  $16, BX
+	ADDQ  $16, DI
+	CMPQ  DI, R10
+	JB    copy_match_overlap32_loop
+
+	MOVOU (AX), X1
+	MOVOU X1, (R10)
+	LEAQ  16(R10), DI
+	XORL  CX, CX
+	JMP   loopcheck
 
 copy_match_from_dict:
 	// CX = match_len
@@ -333,9 +508,9 @@ copy_match_from_dict:
 
 	ADDQ R14, BX
 
-	// if match_len > dict_bytes_available, match fits entirely within external dictionary : just copy
+	// if match_len <= dict_bytes_available, match fits entirely within external dictionary : just copy
 	CMPQ CX, AX
-	JLT memmove_match
+	JBE memmove_match
 
 	// The match stretches over the dictionary and our block
 	// 1) copy what comes from the dictionary
@@ -376,19 +551,13 @@ copy_match_from_dict:
 	// di+=copy_size
 	ADDQ AX, DI
 
-	// 2) copy the rest from the current block
-	// CX = match_len - copy_size = rest_size
+	// 2) copy the rest (> 0 bytes) from the start of the current block:
+	// a match at offset di from &dst.
 	SUBQ AX, CX
 	MOVQ R11, BX
-
-	// check if we have a copy overlap
-	// AX = &dst + rest_size
-	MOVQ CX, AX
-	ADDQ BX, AX
-	// if &dst + rest_size > di, copy byte by byte
-	CMPQ AX, DI
-
-	JA copy_match_loop
+	MOVQ DI, DX
+	SUBQ R11, DX
+	JMP  copy_match_dispatch
 
 memmove_match:
 	// memmove(to, from, len)
@@ -446,3 +615,8 @@ err_short_buf:
 err_short_dict:
 	MOVQ $-3, ret+72(FP)
 	RET
+
+// tileStep[offset] = (16/offset)*offset for offsets 3, 5, 6, 7, 9..15.
+DATA tileStep<>+0(SB)/8, $0x0e0c0f100f101000
+DATA tileStep<>+8(SB)/8, $0x0f0e0d0c0b0a0910
+GLOBL tileStep<>(SB), RODATA|NOPTR, $16

--- a/internal/lz4block/decode_arm64.s
+++ b/internal/lz4block/decode_arm64.s
@@ -56,45 +56,43 @@ TEXT ·decodeBlock(SB), NOSPLIT, $48-80
 	ADD dict, dictlen, dictend
 
 loop:
-	// Read token. Extract literal length.
+	// Read token; >= 0xF0 means literal length 15, slow path.
 	MOVBU.P 1(src), token
-	LSR     $4, token, len
-	CMP     $15, len
-	BEQ     readLitlenLoop        // len == 15: extended read, slow path.
+	CMP     $0xF0, token
+	BHS     readLitlenExt
 
 	// Shortcut: literal length is 0..14. If we also have at least 32 bytes
 	// of dst and 16 bytes of src remaining, copy 16 literal bytes in one
 	// shot, then try to finish the token's match with an 18-byte copy.
 	// Falls back to the slow path on any guard failure. Mirrors the
 	// "copy shortcut" in decode_amd64.s.
-	CMP dstend32, dst
-	BHS readLitlenDone            // <32 bytes left in dst: slow path.
-	CMP srcend16, src
-	BHS readLitlenDone            // <16 bytes left in src: slow path.
+	CMP  dstend32, dst
+	CCMP LO, src, srcend16, $0b0010 // dst >= dstend-32: 0010 sets C (HS).
+	BHS  readLitlenShort            // <32 bytes left in dst or <16 in src: slow path.
 
-	// 16-byte literal copy (bytes past len get overwritten next iter).
+	// 16-byte literal copy (bytes past the literal get overwritten next iter).
 	LDP (src), (tmp1, tmp2)
 	STP (tmp1, tmp2), (dst)
-	ADD len, src
-	ADD len, dst
+	ADD token>>4, src, src
+	ADD token>>4, dst, dst
 
-	// Derive initial matchlen from token's low nibble.
-	AND $15, token, len
-
-	// Read 2-byte offset (src has >=2 bytes left by the guard above).
-	MOVHU (src), offset
-	ADD   $2, src
-	CBZ   offset, corrupt
+	// Initial matchlen from the token's low nibble, then the 2-byte
+	// offset (src has >= 2 bytes left by the guard above).
+	AND     $15, token, len
+	MOVHU.P 2(src), offset
 
 	// Fast-match preconditions: matchlen != 15, offset >= 8, match is
 	// within the current block (>= dstorig -- not a dict reference).
+	// Branches, not a CCMP chain: matchlen == 15 data must leave at the
+	// first test. offset == 0 fails offset >= 8 and is rejected at
+	// readMatchlenChk.
 	CMP $15, len
-	BEQ readMatchlen              // extended matchlen: slow path.
+	BEQ readMatchlenChk
 	CMP $8, offset
-	BLO readMatchlen              // small offset: use existing <8 path.
+	BLO readMatchlenChk
 	SUB offset, dst, match
 	CMP dstorig, match
-	BLO readMatchlen              // dict reference: use existing dict path.
+	BLO readMatchlenChk
 
 	// 18-byte match copy as sequenced 8+8+2 (like the C decoder).
 	// dst-space is guaranteed: dst < dstend-32 and matchlen+minMatch
@@ -110,8 +108,15 @@ loop:
 	MOVH  tmp3, 16(dst)
 	ADD   $const_minMatch, len
 	ADD   len, dst
-	B     copyMatchDone
+	// src < srcend: the guard left >= 17 bytes, the shortcut used <= 16.
+	B     loop
 
+readLitlenShort:
+	LSR $4, token, len
+	B   readLitlenDone
+
+readLitlenExt:
+	MOVD $15, len
 readLitlenLoop:
 	CMP     src, srcend
 	BEQ     shortSrc
@@ -188,7 +193,9 @@ copyLiteralDone:
 	CMP   srcend, src
 	BHI   shortSrc
 	MOVHU -2(src), offset
-	CBZ   offset, corrupt
+
+readMatchlenChk:
+	CBZ offset, corrupt
 
 readMatchlen:
 	// Read rest of match length.
@@ -296,8 +303,7 @@ copyMatchTry8Narrow:
 
 	CMP  $32, len
 	BLO  copyMatchLoop8Setup        // short match: 8-byte loop.
-	CMP  $32, offset
-	BHS  copyMatchLoop8Setup        // offset >= 32 only via the dict remainder path.
+	// offset is 8..31 here (entered with len < 16 or offset <= 31).
 	CMP  $8, offset
 	BEQ  copyMatchTile8
 	CMP  $16, offset
@@ -440,29 +446,18 @@ copyMatchTile24Loop:
 	B    copyMatchTile24Loop
 
 copyMatchTile32:
-	// offset in 17..23, 25..31: prefill one period (8-byte copies never
-	// read ahead of the writes since offset >= 8), so [dst-2*offset, dst)
-	// holds two periods (>= 34 bytes) and dst is phase-aligned; then
-	// store a 32-byte tile from there, advancing by offset. The overlap
-	// between consecutive stores is rewritten with identical bytes.
-	MOVD offset, tmp4
-copyMatchTile32Pre8:
-	MOVD.P 8(match), tmp1
-	MOVD.P tmp1, 8(dst)
-	SUB    $8, tmp4
-	CMP    $8, tmp4
-	BHS    copyMatchTile32Pre8
-	CBZ    tmp4, copyMatchTile32Load
-copyMatchTile32Pre1:
-	MOVBU.P 1(match), tmp1
-	MOVB.P  tmp1, 1(dst)
-	SUBS    $1, tmp4
-	BNE     copyMatchTile32Pre1
-copyMatchTile32Load:
+	// 17..23, 25..31: prefill one period with two 16-byte copies (bytes
+	// 0..15 from match, offset-16..offset-1 from before dst), then store
+	// the 32-byte tile at match every offset bytes.
+	LDP (match), (tmp1, tmp2)
+	LDP -16(dst), (tmp3, tmp4)
+	STP (tmp1, tmp2), (dst)
+	SUB $16, offset, lenRem
+	ADD lenRem, dst, lenRem         // dst + offset - 16
+	STP (tmp3, tmp4), (lenRem)
+	ADD offset, dst
 	SUB offset, len
-	SUB offset<<1, dst, lenRem     // lenRem = dst - 2*offset: tile source.
-	LDP (lenRem), (tmp1, tmp2)
-	LDP 16(lenRem), (tmp3, tmp4)
+	LDP 16(match), (tmp3, tmp4)
 copyMatchTile32Loop:
 	CMP $32, len
 	BLO copyMatchTileTail

--- a/internal/lz4block/fuzz_test.go
+++ b/internal/lz4block/fuzz_test.go
@@ -1,0 +1,95 @@
+package lz4block
+
+import (
+	"bytes"
+	"testing"
+)
+
+// The assembly decoders overrun on purpose when there is room, so both
+// fuzzers check that nothing is written past the destination. Run them
+// with -fuzz on each architecture that has an assembly decoder.
+
+func fuzzSeeds(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("a"))
+	f.Add(bytes.Repeat([]byte("a"), 300))
+	f.Add(bytes.Repeat([]byte("ab"), 300))
+	f.Add(bytes.Repeat([]byte("abcdefgh"), 100))
+	f.Add(bytes.Repeat([]byte("0123456789ab"), 60))
+	f.Add(bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog. "), 40))
+	rec := make([]byte, 0, 4096)
+	for i := 0; i < 64; i++ {
+		rec = append(rec, bytes.Repeat([]byte{byte(i)}, 64)...)
+	}
+	f.Add(rec)
+}
+
+func FuzzBlockRoundTrip(f *testing.F) {
+	fuzzSeeds(f)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		comp := make([]byte, CompressBlockBound(len(data)))
+		var c Compressor
+		n, err := c.CompressBlock(data, comp)
+		if err != nil {
+			t.Fatalf("compress: %v", err)
+		}
+		comp = comp[:n]
+		if n == 0 {
+			// n == 0 means incompressible.
+			return
+		}
+		const guard = 64
+		for _, slack := range []int{0, 1, 15, 16, 17, 31, 32, 33, 64, 1024} {
+			dst := make([]byte, len(data)+slack+guard)
+			for i := range dst {
+				dst[i] = 0xA5
+			}
+			got := decodeBlock(dst[:len(data)+slack], comp, nil)
+			if got != len(data) {
+				t.Fatalf("slack %d: decodeBlock returned %d, want %d", slack, got, len(data))
+			}
+			if !bytes.Equal(dst[:got], data) {
+				t.Fatalf("slack %d: round trip mismatch", slack)
+			}
+			for i := len(data) + slack; i < len(dst); i++ {
+				if dst[i] != 0xA5 {
+					t.Fatalf("slack %d: guard byte %d overwritten", slack, i-len(data)-slack)
+				}
+			}
+		}
+	})
+}
+
+func FuzzDecodeBlockMutated(f *testing.F) {
+	var c Compressor
+	for _, data := range [][]byte{
+		bytes.Repeat([]byte("a"), 300),
+		bytes.Repeat([]byte("abcdefgh"), 100),
+		bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog. "), 40),
+	} {
+		comp := make([]byte, CompressBlockBound(len(data)))
+		n, err := c.CompressBlock(data, comp)
+		if err != nil || n == 0 {
+			f.Fatalf("seed compress: n=%d err=%v", n, err)
+		}
+		f.Add(comp[:n], uint16(len(data)))
+		f.Add(comp[:n], uint16(len(data)/2))
+		f.Add(comp[:n], uint16(len(data)*2))
+	}
+	f.Fuzz(func(t *testing.T, src []byte, dstLen uint16) {
+		const guard = 64
+		dst := make([]byte, int(dstLen)+guard)
+		for i := range dst {
+			dst[i] = 0xA5
+		}
+		n := decodeBlock(dst[:dstLen], src, nil)
+		if n > int(dstLen) {
+			t.Fatalf("decodeBlock returned %d for a %d byte destination", n, dstLen)
+		}
+		for i := int(dstLen); i < len(dst); i++ {
+			if dst[i] != 0xA5 {
+				t.Fatalf("guard byte %d overwritten (n=%d)", i-int(dstLen), n)
+			}
+		}
+	})
+}

--- a/internal/lz4block/match_copy_test.go
+++ b/internal/lz4block/match_copy_test.go
@@ -3,6 +3,7 @@ package lz4block
 import (
 	"bytes"
 	"encoding/binary"
+	"math/rand"
 	"testing"
 )
 
@@ -237,6 +238,135 @@ func TestMatchCopyChained(t *testing.T) {
 		for i := 0; i < n; i++ {
 			if dst[i] != want[i] {
 				t.Fatalf("first mismatch at byte %d: got 0x%02x want 0x%02x", i, dst[i], want[i])
+			}
+		}
+	}
+}
+
+// TestMatchCopyMatrixSlack repeats the matrix sweep into a dst that has
+// room past the decoded output. TestMatchCopyMatrix sizes dst exactly, so
+// every match tail runs against the end of the buffer; this variant takes
+// the paths that may store past the end of the match (the overrun is
+// inside dst and is not part of the returned output).
+func TestMatchCopyMatrixSlack(t *testing.T) {
+	offsets := []int{1, 2, 3, 4, 5, 6, 7}
+	for o := 8; o <= 33; o++ {
+		offsets = append(offsets, o)
+	}
+	offsets = append(offsets, 48, 64, 127, 128, 255, 256, 1024)
+	var mlens []int
+	for l := minMatch; l <= 64; l++ {
+		mlens = append(mlens, l)
+	}
+	mlens = append(mlens, 65, 66, 71, 72, 79, 80, 95, 96, 100, 127, 128, 255, 256, 257, 1023, 4096)
+
+	for _, off := range offsets {
+		for _, mlen := range mlens {
+			prefix := off
+			if prefix < 16 {
+				prefix = 16
+			}
+			src, want := buildSingleMatchBlock(prefix, off, mlen)
+			for _, slack := range []int{1, 15, 16, 31, 32, 64} {
+				dst := make([]byte, len(want)+slack)
+				n := decodeBlock(dst, src, nil)
+				if n != len(want) {
+					t.Fatalf("off=%d mlen=%d slack=%d: decode returned %d, want %d",
+						off, mlen, slack, n, len(want))
+				}
+				if !bytes.Equal(dst[:n], want) {
+					for i := 0; i < n; i++ {
+						if dst[i] != want[i] {
+							t.Fatalf("off=%d mlen=%d slack=%d: first mismatch at byte %d: got 0x%02x want 0x%02x",
+								off, mlen, slack, i, dst[i], want[i])
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestMatchCopyRandomSequences decodes seeded random blocks of many
+// sequences with small, medium and large offsets and lengths, so the
+// paths interact in orders the single-match tests do not produce. The
+// output buffer carries guard bytes after dst to catch any store past the
+// slice the decoder was given.
+func TestMatchCopyRandomSequences(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	const guard = 64
+	for iter := 0; iter < 4000; iter++ {
+		var buf bytes.Buffer
+		var want []byte
+		nseq := 1 + rng.Intn(24)
+		for i := 0; i < nseq; i++ {
+			litlen := rng.Intn(20)
+			if rng.Intn(8) == 0 {
+				litlen = rng.Intn(300)
+			}
+			if len(want) == 0 && litlen == 0 {
+				litlen = 1
+			}
+			lit := make([]byte, litlen)
+			rng.Read(lit)
+			last := i == nseq-1
+			if last {
+				writeToken(&buf, litlen, 0)
+				buf.Write(lit)
+				want = append(want, lit...)
+				break
+			}
+			mlen := minMatch + rng.Intn(40)
+			switch rng.Intn(6) {
+			case 0:
+				mlen = minMatch + rng.Intn(600)
+			case 1:
+				mlen = minMatch + 200 + rng.Intn(2000)
+			}
+			writeToken(&buf, litlen, mlen-minMatch)
+			buf.Write(lit)
+			want = append(want, lit...)
+			var off int
+			switch rng.Intn(4) {
+			case 0:
+				off = 1 + rng.Intn(8)
+			case 1:
+				off = 1 + rng.Intn(40)
+			default:
+				off = 1 + rng.Intn(600)
+			}
+			if off > len(want) {
+				off = len(want)
+			}
+			o := make([]byte, 2)
+			binary.LittleEndian.PutUint16(o, uint16(off))
+			buf.Write(o)
+			if rawM := mlen - minMatch; rawM >= 15 {
+				writeExtended(&buf, rawM-15)
+			}
+			start := len(want)
+			for j := 0; j < mlen; j++ {
+				want = append(want, want[start-off+j])
+			}
+		}
+		src := buf.Bytes()
+		for _, slack := range []int{0, 7, 33} {
+			dst := make([]byte, len(want)+slack+guard)
+			n := decodeBlock(dst[:len(want)+slack], src, nil)
+			if n != len(want) {
+				t.Fatalf("iter %d slack %d: decode returned %d, want %d", iter, slack, n, len(want))
+			}
+			if !bytes.Equal(dst[:n], want) {
+				for i := 0; i < n; i++ {
+					if dst[i] != want[i] {
+						t.Fatalf("iter %d slack %d: first mismatch at byte %d of %d", iter, slack, i, n)
+					}
+				}
+			}
+			for i := len(want) + slack; i < len(dst); i++ {
+				if dst[i] != 0 {
+					t.Fatalf("iter %d slack %d: guard byte %d written", iter, slack, i-len(want)-slack)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Brings the amd64 decoder up to parity with the arm64 one. #246 and #248 gave arm64 splat and tile stores for overlapping matches and inline copies for medium non-overlapping ones; amd64 still copied every overlapping match one byte at a time, each load waiting on the store one byte earlier, and called `runtime·memmove` for anything over 16 bytes. That is why the amd64 numbers below are an order of magnitude on the RLE cases while the arm64 commit here is a few percent: arm64 already had this, and its commit is the smaller per-sequence follow-up. Measured on Zen 3/4/5 and Sapphire Rapids, and on Neoverse N1, Cortex-A72 and Graviton3/4/5 (Neoverse V1/V2/V3). Three commits, each bisectable:

1. **amd64: inline match copies, splat and tile stores for overlapping matches.** The amd64 decoder copied every overlapping match byte by byte and sent every non-overlapping match over 16 bytes through `runtime·memmove` with a full register spill. Overlapping matches now splat (offsets 1, 2, 4, 8, 16) or tile (3, 5, 6, 7, 9..31) through XMM stores; non-overlapping 17..255-byte matches use an inline 16-byte loop with an exact final chunk; 256 and up still call memmove (64 and 1024 were measured and both lose).
2. **arm64: shorter shortcut path, prefill for overlapping offsets 17..31.** The per-sequence shortcut goes from 34 to 28 instructions (token >= 0xF0 test, one CCMP for the two room guards, shifted-operand literal advance, post-incremented offset read, direct branch back to the loop), and long matches at offsets 17..31 prefill with two 16-byte copies instead of byte loops. Two further variants, a CCMP chain for the match preconditions and a register-built tile for offsets 9..15, were measured on all five cores and rejected; the numbers are in the commit message.
3. **benchmarks and fuzzers.** `BenchmarkUncompress` fed a frame to the raw block decoder and returned an error in 7 ns; it now decodes a real block. Adds a bzImage raw-block benchmark (the binary-shaped corpus: half literal bytes), RLE48/64 (overlapping offsets beyond the tiles) and Columnar128/256 (locates the inline-vs-memmove crossover). Adds `FuzzBlockRoundTrip` and `FuzzDecodeBlockMutated`, native fuzz targets that check round trips at several destination slacks and that a corrupt block never writes past its destination.

### Results (8 interleaved rounds, pinned, `benchstat`, against v4 HEAD)

amd64, Zen 3 (Ryzen 5 5600X):

| benchmark | change |
|---|---|
| RLE offsets 1..31 | 90 to 99% less time (0.3-1.9 ms to 23-34 µs) |
| RLE offsets 48, 64 | 85% less |
| ColumnarShort / Med / Long | -41% / -17% / -42% |
| bzImage raw block | -44% |
| Pg1661, Twain, Digits, Rand frames | unchanged |

Same protocol on AWS datacentre x86, one pinned core each, to check the Zen 3 desktop numbers are not an artefact of that box (the base decoder copies overlapping matches one byte at a time with a load-after-store dependency per byte, which is why the RLE cases move by an order of magnitude):

| benchmark | Zen 4 (EPYC 9R14, m7a) | Zen 5 (EPYC 9R45, c8a) | Sapphire Rapids (Xeon 8488C, c7i) |
|---|---|---|---|
| RLE offsets 1..31 | -93 to -99% | -92 to -98% | -88 to -97% |
| RLE offsets 48, 64 | -87%, -90% | -83%, -87% | -83%, -86% |
| ColumnarShort / 128 / 256 / Med / Long | -45 / -17 / -9 / -18 / -47% | -28 / -19 / -11 / -23 / -46% | -29 / -11 / -12 / -20 / -32% |
| bzImage raw block | -60% | -54% | -39% |
| Pg1661 raw block | -1.2% | -1.6% | -0.3% |
| Pg1661, Twain, Digits frames | -0.3 to -0.9% | -0.6 to -0.9% | ~ |

arm64, final state of the branch against v4 HEAD (Pg1661 frame / raw block / ColumnarShort):

| core | Pg1661 frame | Pg1661 block | ColumnarShort |
|---|---|---|---|
| Neoverse N1 (Altra) | -5.6% | -7.6% | -7.2% |
| Cortex-A72 | -2.0% | -1.5% | ~ |
| Graviton3 (V1) | -3.5% | -4.7% | ~ (+1.2%) |
| Graviton4 (V2) | -3.3% | -3.2% | -2.7% |
| Graviton5 (V3) | ~ (+0.4%) | ~ (+0.7%) | -3.3% |

bzImage block on V3 is -14.7%. Nothing regresses beyond noise on any core.

Tests: full suites on amd64 and natively on all five arm64 cores; both fuzzers ran two minutes each on Zen 3 and on N1 with no findings.

Semantics unchanged: every overrunning store is guarded by the same destination-room checks as before, and the mutation fuzzer's guard bytes check exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
