### PR TITLE
ci: roll test matrix forward to go1.25-1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ["1.24", "1.25", "1.26", "1.27"]
+        go: ["1.25", "1.26", "1.27"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ["1.24", "1.25", "1.26"]
+        go: ["1.24", "1.25", "1.26", "1.27"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add go1.27 to the CI test matrix and drop go1.24, keeping the matrix at the repo's established 3-version window.
- Go's own support policy covers only the last two majors (currently 1.26/1.27); 1.24 is already outside that window, so rolling the matrix forward to 1.25/1.26/1.27 tracks the same cadence used in prior matrix updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)